### PR TITLE
Cleanup SM image after smart contracts deployment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,20 @@ jobs:
       - name: Deploy manager & ima contracts
         run: |
           bash ./helper-scripts/deploy_test_ima.sh
+          docker rmi -f skalenetwork/skale-manager:${{ env.MANAGER_TAG }}
+      - name: Show stats before tests
+        if: always()
+        run: | 
+          sudo lsblk -f
+          sudo free -h
       - name: Run core tests
         run: |
           bash ./scripts/run_core_tests.sh
+      - name: Show stats after tests
+        if: always()
+        run: | 
+          sudo lsblk -f
+          sudo free -h
       - name: Run codecov
         run: |
           codecov -t $CODECOV_TOKEN


### PR DESCRIPTION
Remove skale-manager docker image to reduce occupied disk space. 
No source code touched, no performance changes made. 