### PR TITLE
Cleanup skale-manager image after deployment. Fix tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,20 @@ jobs:
       - name: Deploy manager & ima contracts
         run: |
           bash ./helper-scripts/deploy_test_ima.sh
+          docker rmi -f skalenetwork/skale-manager:${{ env.MANAGER_TAG }}
+      - name: Show stats before tests
+        if: always()
+        run: | 
+          sudo lsblk -f
+          sudo free -h
       - name: Run core tests
         run: |
           bash ./scripts/run_core_tests.sh
+      - name: Show stats after tests
+        if: always()
+        run: | 
+          sudo lsblk -f
+          sudo free -h
       - name: Run codecov
         run: |
           codecov -t $CODECOV_TOKEN

--- a/core/schains/monitor/action.py
+++ b/core/schains/monitor/action.py
@@ -299,7 +299,7 @@ class SkaledActionManager(BaseActionManager):
         self,
         download_snapshot: bool = False,
         start_ts: Optional[int] = None,
-        ignore_reached_exit: bool = True,
+        abort_on_exit: bool = True,
     ) -> bool:
         logger.info(
             'Starting skaled container watchman snapshot: %s, start_ts: %s',
@@ -312,7 +312,7 @@ class SkaledActionManager(BaseActionManager):
             skaled_status=self.skaled_status,
             download_snapshot=download_snapshot,
             start_ts=start_ts,
-            ignore_reached_exit=ignore_reached_exit,
+            abort_on_exit=abort_on_exit,
             dutils=self.dutils
         )
         time.sleep(CONTAINER_POST_RUN_DELAY)
@@ -349,7 +349,7 @@ class SkaledActionManager(BaseActionManager):
         return True
 
     @BaseActionManager.monitor_block
-    def reloaded_skaled_container(self, ignore_reached_exit: bool = True) -> bool:
+    def reloaded_skaled_container(self, abort_on_exit: bool = True) -> bool:
         logger.info('Starting skaled from scratch')
         initial_status = True
         if is_container_exists(self.name, dutils=self.dutils):
@@ -361,11 +361,11 @@ class SkaledActionManager(BaseActionManager):
         self.schain_record.set_failed_rpc_count(0)
         self.schain_record.set_needs_reload(False)
         initial_status = self.skaled_container(
-            ignore_reached_exit=ignore_reached_exit)
+            abort_on_exit=abort_on_exit)
         return initial_status
 
     @BaseActionManager.monitor_block
-    def recreated_schain_containers(self, ignore_reached_exit: bool = True) -> bool:
+    def recreated_schain_containers(self, abort_on_exit: bool = True) -> bool:
         logger.info('Restart skaled and IMA from scratch')
         initial_status = True
         # Remove IMA -> skaled, start skaled -> IMA
@@ -379,7 +379,7 @@ class SkaledActionManager(BaseActionManager):
         self.schain_record.set_restart_count(0)
         self.schain_record.set_failed_rpc_count(0)
         self.schain_record.set_needs_reload(False)
-        self.skaled_container()
+        self.skaled_container(abort_on_exit=abort_on_exit)
         self.ima_container()
         return initial_status
 

--- a/core/schains/monitor/containers.py
+++ b/core/schains/monitor/containers.py
@@ -52,7 +52,7 @@ def monitor_schain_container(
     skaled_status,
     download_snapshot=False,
     start_ts=None,
-    ignore_reached_exit: bool = True,
+    abort_on_exit: bool = True,
     dutils=None
 ) -> None:
     dutils = dutils or DockerUtils()
@@ -63,7 +63,7 @@ def monitor_schain_container(
         logger.error(f'Data volume for sChain {schain_name} does not exist')
         return
 
-    if skaled_status.exit_time_reached and ignore_reached_exit:
+    if skaled_status.exit_time_reached and abort_on_exit:
         logger.info(
             f'{schain_name} - Skipping container monitor: exit time reached')
         skaled_status.log()

--- a/core/schains/monitor/skaled_monitor.py
+++ b/core/schains/monitor/skaled_monitor.py
@@ -145,7 +145,7 @@ class UpdateConfigSkaledMonitor(BaseSkaledMonitor):
             self.am.firewall_rules()
         if not self.checks.volume:
             self.am.volume()
-        self.am.recreated_schain_containers(ignore_reached_exit=False)
+        self.am.recreated_schain_containers(abort_on_exit=False)
 
 
 class NewConfigSkaledMonitor(BaseSkaledMonitor):

--- a/tests/schains/monitor/action/skaled_action_test.py
+++ b/tests/schains/monitor/action/skaled_action_test.py
@@ -39,13 +39,13 @@ def monitor_schain_container_mock(
     skaled_status,
     download_snapshot=False,
     start_ts=None,
-    ignore_reached_exit=True,
+    abort_on_exit=True,
     dutils=None
 ):
     image_name, container_name, _, _ = get_container_info(
         SCHAIN_CONTAINER, schain['name'])
     dutils.safe_rm(container_name)
-    if not skaled_status.exit_time_reached or not ignore_reached_exit:
+    if not skaled_status.exit_time_reached or not abort_on_exit:
         dutils.run_container(
             image_name=image_name,
             name=container_name,
@@ -134,7 +134,7 @@ def test_skaled_container_with_snapshot_action(skaled_am):
             skaled_status=skaled_am.skaled_status,
             download_snapshot=True,
             start_ts=None,
-            ignore_reached_exit=True,
+            abort_on_exit=True,
             dutils=skaled_am.dutils
         )
         assert monitor_schain_mock.call_count == 1
@@ -158,7 +158,7 @@ def test_skaled_container_snapshot_delay_start_action(skaled_am):
             skaled_status=skaled_am.skaled_status,
             download_snapshot=True,
             start_ts=ts,
-            ignore_reached_exit=True,
+            abort_on_exit=True,
             dutils=skaled_am.dutils
         )
         assert monitor_schain_mock.call_count == 1
@@ -200,7 +200,7 @@ def test_restart_skaled_container_action_exit_reached(
             assert not skaled_checks.skaled_container
             skaled_am.reloaded_skaled_container()
             assert not skaled_checks.skaled_container
-            skaled_am.reloaded_skaled_container(ignore_reached_exit=False)
+            skaled_am.reloaded_skaled_container(abort_on_exit=False)
             assert skaled_checks.skaled_container
     finally:
         skaled_am.cleanup_schain_docker_entity()

--- a/tests/schains/monitor/containers_test.py
+++ b/tests/schains/monitor/containers_test.py
@@ -54,7 +54,7 @@ def test_monitor_schain_container_exit_time_reached(
             schain,
             schain_record,
             skaled_status_exit_time_reached,
-            ignore_reached_exit=False,
+            abort_on_exit=False,
             dutils=dutils
         )
         assert len(dutils.get_all_schain_containers()) == 1


### PR DESCRIPTION
Remove skale-manager docker image to reduce occupied disk space.
No source code touched, no performance changes made.

