### PR TITLE
Return IMA agent version after migration in schains/containers route

### DIFF
--- a/core/schains/ima.py
+++ b/core/schains/ima.py
@@ -181,8 +181,8 @@ def get_ima_env(schain_name: str, mainnet_chain_id: int) -> ImaEnv:
     )
 
 
-def get_ima_version() -> str:
-    return CONTAINERS_INFO['ima']['version']
+def get_ima_version_after_migration() -> str:
+    return CONTAINERS_INFO['ima'].get('new_version') or CONTAINERS_INFO['ima']['version']
 
 
 def get_ima_monitoring_port(schain_name):

--- a/tests/routes/schains_test.py
+++ b/tests/routes/schains_test.py
@@ -172,19 +172,14 @@ def test_get_schain(
 
 
 def test_schain_containers_versions(skale_bp):
-    skaled_version = '3.7.3-develop.4'
-    ima_version = '1.1.0-beta.0'
-    with mock.patch(
-        'web.routes.schains.get_skaled_version',
-        return_value=skaled_version
-    ), mock.patch('web.routes.schains.get_ima_version',
-                  return_value=ima_version):
-        data = get_bp_data(skale_bp, get_api_url(
-            BLUEPRINT_NAME, 'container-versions'))
-        assert data == {
-            'status': 'ok',
-            'payload': {
-                'skaled_version': skaled_version,
-                'ima_version': ima_version
-            }
+    expected_skaled_version = '3.16.1'
+    expected_ima_version = '2.0.0-beta.9'
+    data = get_bp_data(skale_bp, get_api_url(
+        BLUEPRINT_NAME, 'container-versions'))
+    assert data == {
+        'status': 'ok',
+        'payload': {
+            'skaled_version': expected_skaled_version,
+            'ima_version': expected_ima_version
         }
+    }

--- a/web/routes/schains.py
+++ b/web/routes/schains.py
@@ -32,7 +32,7 @@ from core.schains.firewall.utils import (
     get_sync_agent_ranges
 )
 from core.schains.skaled_status import init_skaled_status
-from core.schains.ima import get_ima_version
+from core.schains.ima import get_ima_version_after_migration
 from core.schains.info import get_schain_info_by_name, get_skaled_version
 from core.schains.cleaner import get_schains_on_node
 from web.models.schain import get_schains_statuses, toggle_schain_repair_mode
@@ -166,6 +166,6 @@ def schain_containers_versions():
     logger.debug(request)
     version_data = {
         'skaled_version': get_skaled_version(),
-        'ima_version': get_ima_version()
+        'ima_version': get_ima_version_after_migration()
     }
     return construct_ok_response(version_data)


### PR DESCRIPTION
Changes:
- Return IMA agent version after migration in schains/containers route. If it's not specified, return the regular one. 

Peformance:
- No performance changes were introduced. 

Unit tests:
- Fixed existing unit test.

Testing:
- Tested on local network by requesting `curl http://127.0.0.1:3009/status/schain-containers-versions`. 