### PR TITLE
Fix skaled config broken by automatic repair option

### DIFF
--- a/core/schains/config/static_params.py
+++ b/core/schains/config/static_params.py
@@ -39,4 +39,7 @@ def get_static_node_info(schain_type: SchainType, env_type: str = ENV_TYPE) -> d
 
 def get_automatic_repair_option(env_type: str = ENV_TYPE) -> bool:
     static_params = get_static_params(env_type)
-    return static_params['node']['common'].get('automatic_repair', True)
+    node_params = static_params['node']
+    if 'admin' in node_params:
+        return node_params['admin'].get('automatic_repair', True)
+    return True

--- a/tests/schains/config/static_params_test.py
+++ b/tests/schains/config/static_params_test.py
@@ -37,4 +37,7 @@ def test_get_static_node_info():
 
 def test_get_automatic_repair_option():
     assert get_automatic_repair_option()
+    assert get_automatic_repair_option(env_type='mainnet')
+    assert get_automatic_repair_option(env_type='testnet')
+    assert get_automatic_repair_option(env_type='devnet')
     assert not get_automatic_repair_option(env_type='qanet')

--- a/tests/skale-data/config/static_params.yaml
+++ b/tests/skale-data/config/static_params.yaml
@@ -192,11 +192,12 @@ envs:
       ["-v 3", "--web3-trace", "--enable-debug-behavior-apis", "--aa no"]
 
     node:
+      admin:
+        automatic_repair: false
       common:
         bindIP: "0.0.0.0"
         logLevel: "info"
         logLevelConfig: "info"
-        automatic_repair: false
       small:
         minCacheSize: 1000000
         maxCacheSize: 2000000
@@ -266,6 +267,8 @@ envs:
       ["-v 3", "--web3-trace", "--enable-debug-behavior-apis", "--aa no"]
 
     node:
+      admin:
+        automatic_repair: true
       common:
         bindIP: "0.0.0.0"
         logLevel: "info"


### PR DESCRIPTION
Changes:
- Fixed schain config generation (new option ended up in schain config itself, but skaled does not allow any unused options) by moving `automatic_repair` to `node` -> `admin` section

Peformance:
- No performance related changes were made

Unit tests:
- Modified existing unit tests

Testing:
- Tested on local network by creating schain. 