### PR TITLE
Sync node stable (hotfix for 2.3 release)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,26 @@ jobs:
         run: bash ./scripts/install_python_dependencies.sh
       - name: Lint with flake8
         run: flake8 .
+      - name: Launch anvil node
+        run: |
+          docker run -d --network host --name anvil ghcr.io/foundry-rs/foundry anvil && sleep 5 && docker logs anvil --tail 1000
       - name: Deploy manager & ima contracts
         run: |
           bash ./helper-scripts/deploy_test_ima.sh
+          docker rmi -f skalenetwork/skale-manager:${{ env.MANAGER_TAG }}
+      - name: Show stats before tests
+        if: always()
+        run: | 
+          sudo lsblk -f
+          sudo free -h
       - name: Run core tests
         run: |
           bash ./scripts/run_core_tests.sh
+      - name: Show stats after tests
+        if: always()
+        run: | 
+          sudo lsblk -f
+          sudo free -h
       - name: Run codecov
         run: |
           codecov -t $CODECOV_TOKEN

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 env:
   ETH_PRIVATE_KEY: ${{ secrets.ETH_PRIVATE_KEY }}
   SCHAIN_TYPE: ${{ secrets.SCHAIN_TYPE }}
-  MANAGER_TAG: "1.9.3-beta.0"
+  MANAGER_TAG: "1.10.0-beta.0"
   IMA_TAG: "1.3.4-beta.5"
   SGX_WALLET_TAG: "1.83.0-beta.5"
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "helper-scripts"]
 	path = helper-scripts
 	url = https://github.com/skalenetwork/helper-scripts.git
-	branch = develop
+    branch = fix-for-latest-sm

--- a/core/schains/config/node_info.py
+++ b/core/schains/config/node_info.py
@@ -84,7 +84,12 @@ def generate_current_node_info(
         node['port']
     )
 
-    wallets = {} if sync_node else generate_wallets_config(schain['name'], rotation_id)
+    wallets = generate_wallets_config(
+        schain['name'],
+        rotation_id,
+        schain_nodes_number=len(schains_on_node),
+        sync_node=sync_node
+    )
 
     if ecdsa_key_name is None:
         logger.warning(f'Generating CurrentNodeInfo for {schain["name"]}, ecdsa_key_name is None')
@@ -105,7 +110,16 @@ def generate_current_node_info(
     )
 
 
-def generate_wallets_config(schain_name: str, rotation_id: int) -> dict:
+def generate_wallets_config(
+    schain_name: str,
+    rotation_id: int,
+    schain_nodes_number: int,
+    sync_node: bool = False
+) -> dict:
+    if sync_node:
+        return {
+            'ima': {'n': schain_nodes_number}
+        }
     secret_key_share_filepath = get_secret_key_share_filepath(schain_name, rotation_id)
     secret_key_share_config = read_json(secret_key_share_filepath)
 

--- a/core/schains/config/node_info.py
+++ b/core/schains/config/node_info.py
@@ -127,7 +127,7 @@ def generate_wallets_config(
         'ima': {
             'keyShareName': secret_key_share_config['key_share_name'],
             't': secret_key_share_config['t'],
-            'n': secret_key_share_config['n'],
+            'n': schain_nodes_number,
             'certFile': SGX_SSL_CERT_FILEPATH,
             'keyFile': SGX_SSL_KEY_FILEPATH
         }

--- a/tests/dkg_test/main_test.py
+++ b/tests/dkg_test/main_test.py
@@ -231,6 +231,7 @@ class TestDKG:
             remove_schain(skale, schain_name)
             cleanup_schain_config(schain_name)
 
+    @pytest.mark.skip('Not used in sync node')
     def test_dkg_procedure(
         self,
         skale,
@@ -290,6 +291,7 @@ class TestDKG:
         finally:
             skale.schains_internal.get_node_ids_for_schain = get_node_ids_f
 
+    @pytest.mark.skip('Not used in sync node')
     def test_failed_get_dkg_client(self, no_ids_for_schain_skale):
         skale = no_ids_for_schain_skale
         with pytest.raises(DkgError):

--- a/tests/node_test.py
+++ b/tests/node_test.py
@@ -92,6 +92,7 @@ def test_create_insufficient_funds(unregistered_node):
         assert res['errors'] == ['Insufficient funds, re-check your wallet']
 
 
+@pytest.mark.skip('No need for sync node')
 def test_register_info(unregistered_node):
     unregistered_node.config.id = None
     ip, public_ip, port, name = generate_random_node_data()

--- a/tests/schains/config/node_info_test.py
+++ b/tests/schains/config/node_info_test.py
@@ -20,16 +20,20 @@ def test_generate_wallets_config():
     with mock.patch('core.schains.config.node_info.read_json', return_value=SECRET_KEY_MOCK):
         wallets = generate_wallets_config('test_schain', 0, 4)
 
-    assert wallets['ima']['keyShareName'] == SECRET_KEY_MOCK['key_share_name']
-    assert wallets['ima']['certFile'] == SGX_SSL_CERT_FILEPATH
-    assert wallets['ima']['keyFile'] == SGX_SSL_KEY_FILEPATH
-    assert wallets['ima']['n'] == 4
-    assert wallets['ima']['commonBLSPublicKey0'] == '1'
-    assert wallets['ima']['commonBLSPublicKey1'] == '1'
-    assert wallets['ima']['commonBLSPublicKey2'] == '1'
-    assert wallets['ima']['BLSPublicKey0'] == '1'
-    assert wallets['ima']['BLSPublicKey1'] == '1'
-    assert wallets['ima']['BLSPublicKey2'] == '1'
+        assert wallets['ima']['keyShareName'] == SECRET_KEY_MOCK['key_share_name']
+        assert wallets['ima']['certFile'] == SGX_SSL_CERT_FILEPATH
+        assert wallets['ima']['keyFile'] == SGX_SSL_KEY_FILEPATH
+        assert wallets['ima']['n'] == 4
+        assert wallets['ima']['commonBLSPublicKey0'] == '1'
+        assert wallets['ima']['commonBLSPublicKey1'] == '1'
+        assert wallets['ima']['commonBLSPublicKey2'] == '1'
+        assert wallets['ima']['BLSPublicKey0'] == '1'
+        assert wallets['ima']['BLSPublicKey1'] == '1'
+        assert wallets['ima']['BLSPublicKey2'] == '1'
+
+    with mock.patch('core.schains.config.node_info.read_json', return_value=SECRET_KEY_MOCK):
+        wallets = generate_wallets_config('test_schain', 0, 4, sync_node=True)
+        assert wallets['ima']['n'] == 4
 
 
 def test_generate_current_node_info(

--- a/tests/schains/config/node_info_test.py
+++ b/tests/schains/config/node_info_test.py
@@ -18,11 +18,12 @@ SCHAIN_NAME = 'test_schain'
 
 def test_generate_wallets_config():
     with mock.patch('core.schains.config.node_info.read_json', return_value=SECRET_KEY_MOCK):
-        wallets = generate_wallets_config('test_schain', 0)
+        wallets = generate_wallets_config('test_schain', 0, 4)
 
     assert wallets['ima']['keyShareName'] == SECRET_KEY_MOCK['key_share_name']
     assert wallets['ima']['certFile'] == SGX_SSL_CERT_FILEPATH
     assert wallets['ima']['keyFile'] == SGX_SSL_KEY_FILEPATH
+    assert wallets['ima']['n'] == 4
     assert wallets['ima']['commonBLSPublicKey0'] == '1'
     assert wallets['ima']['commonBLSPublicKey1'] == '1'
     assert wallets['ima']['commonBLSPublicKey2'] == '1'


### PR DESCRIPTION
Workaround for 2.3 release sync node: save n field into schain config ima wallets section.
No performance related changes.
Modified unit tests. No additional ones needed.
Should be merged separetely to 2.7.x