### PR TITLE
Fix docker.py. Remove unnecessary telegraf token field

### DIFF
--- a/core/monitoring.py
+++ b/core/monitoring.py
@@ -27,7 +27,7 @@ from tools.configs import SKALE_DIR_HOST
 from tools.configs.monitoring import (
     FILEBEAT_TEMPLATE_PATH, FILEBEAT_CONTAINER_NAME,
     FILEBEAT_CONFIG_PATH,
-    INFLUX_TOKEN, INFLUX_URL,
+    INFLUX_URL,
     TELEGRAF,
     TELEGRAF_CONTAINER_NAME, TELEGRAF_IMAGE,
     TELEGRAF_TEMPLATE_PATH,
@@ -64,6 +64,7 @@ def filebeat_config_processed() -> bool:
 
 
 def ensure_telegraf_running(dutils: Optional[DockerUtils] = None) -> None:
+    dutils = dutils or DockerUtils()
     if dutils.is_container_exists(TELEGRAF_CONTAINER_NAME):
         dutils.restart(TELEGRAF_CONTAINER_NAME)
     else:
@@ -87,7 +88,6 @@ def ensure_telegraf_running(dutils: Optional[DockerUtils] = None) -> None:
 def update_telegraf_service(
     node_ip: str,
     node_id: int,
-    token: str = INFLUX_TOKEN,
     url: str = INFLUX_URL,
     dutils: Optional[DockerUtils] = None
 ) -> None:
@@ -95,7 +95,6 @@ def update_telegraf_service(
     template_data = {
         'ip': node_ip,
         'node_id': str(node_id),
-        'token': token,
         'url': url
     }
     missing = list(filter(lambda k: not template_data[k], template_data))
@@ -117,6 +116,6 @@ def telegraf_config_processed() -> bool:
 
 
 def update_monitoring_services(node_ip, node_id, skale, dutils: Optional[DockerUtils] = None):
-    update_filebeat_service(node_ip, node_id, skale)
+    update_filebeat_service(node_ip, node_id, skale, dutils=dutils)
     if TELEGRAF:
-        update_telegraf_service(node_ip, node_id)
+        update_telegraf_service(node_ip, node_id, dutils=dutils)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ python-iptables==1.0.1
 
 skale.py==6.2b0
 
+requests==2.31
 ima-predeployed==2.1.0b0
 etherbase-predeployed==1.1.0b3
 marionette-predeployed==2.0.0b2

--- a/tests/monitoring_test.py
+++ b/tests/monitoring_test.py
@@ -21,7 +21,7 @@ CONFIG_TEMPLATE = """
 [[outputs.db]]
   alias = "db"
   urls = ["{{ url }}"]
-  header = {"Token" = "{{ token }}"}
+
 """
 
 
@@ -49,9 +49,8 @@ def test_update_telegraf_service(telegraf_template, cleanup_container, dutils):
     node_ip = '1.1.1.1'
     with pytest.raises(TelegrafNotConfiguredError):
         update_telegraf_service(
-            node_id,
-            node_ip,
-            token='',
+            node_id=node_id,
+            node_ip='',
             url='http://127.0.0.1:1231',
             dutils=dutils
         )
@@ -59,11 +58,10 @@ def test_update_telegraf_service(telegraf_template, cleanup_container, dutils):
     update_telegraf_service(
         node_ip,
         node_id,
-        token='token',
         url='http://127.0.0.1:1231',
         dutils=dutils
     )
     with open(TELEGRAF_CONFIG_PATH) as config:
         config = config.read()
-        assert config == '\n[agent]\n  interval = "60s"\n  hostname = "1.1.1.1"\n  omit_hostname = false\n\n[global_tags]\n  node_id = "1"\n\n[[outputs.db]]\n  alias = "db"\n  urls = ["http://127.0.0.1:1231"]\n  header = {"Token" = "token"}'  # noqa
+        assert config == '\n[agent]\n  interval = "60s"\n  hostname = "1.1.1.1"\n  omit_hostname = false\n\n[global_tags]\n  node_id = "1"\n\n[[outputs.db]]\n  alias = "db"\n  urls = ["http://127.0.0.1:1231"]\n'  # noqa
     assert dutils.is_container_running('skale_telegraf')

--- a/tools/configs/monitoring.py
+++ b/tools/configs/monitoring.py
@@ -8,7 +8,6 @@ FILEBEAT_CONTAINER_NAME = 'skale_filebeat'
 
 MONITORING_CONTAINERS = os.getenv('MONITORING_CONTAINERS') == 'True'
 
-INFLUX_TOKEN = os.getenv('INFLUX_TOKEN')
 INFLUX_URL = os.getenv('INFLUX_URL')
 
 TELEGRAF = os.getenv('TELEGRAF') == 'True'


### PR DESCRIPTION
Changes
- Fixes docker.py. Related to https://github.com/docker/docker-py/issues/3256.
- Remove unused influx token field.

Tests:
- Fixed unit tests.
- Tested on local network. 

Performance:
- No performance releated changes were introduced.