### PR TITLE
Improve SGX check

### DIFF
--- a/tests/routes/health_test.py
+++ b/tests/routes/health_test.py
@@ -159,8 +159,8 @@ def test_sgx(skale_bp, skale):
     assert data == {
         'payload': {
             'sgx_server_url': SGX_SERVER_URL,
-            'status': 0,
-            'status_name': 'CONNECTED',
+            'status_zmq': True,
+            'status_https': True,
             'sgx_wallet_version': version,
             'sgx_keyname': TEST_SGX_KEYNAME,
         },

--- a/web/routes/health.py
+++ b/web/routes/health.py
@@ -132,24 +132,24 @@ def ima_log_checks():
 @health_bp.route(get_api_url(BLUEPRINT_NAME, 'sgx'), methods=['GET'])
 def sgx_info():
     logger.debug(request)
-    sgx = SgxClient(SGX_SERVER_URL, SGX_CERTIFICATES_FOLDER)
-    status_https = False
     status_zmq = False
+    status_https = False
     version = None
+    sgx = SgxClient(SGX_SERVER_URL, SGX_CERTIFICATES_FOLDER, zmq=True)
     try:
-        if sgx.get_server_status() == 0:
-            status_https = True
-        version = sgx.get_server_version()
-    except Exception as e:  # todo: catch specific error - edit sgx.py
-        logger.info(e)
-    sgx_zmq = SgxClient(SGX_SERVER_URL, SGX_CERTIFICATES_FOLDER, zmq=True)
-    try:
-        if sgx_zmq.zmq.get_server_status() == 0:
+        if sgx.zmq.get_server_status() == 0:
             status_zmq = True
+        version = sgx.zmq.get_server_version()
+    except Exception as err:
+        logger.error(f'Cannot make SGX ZMQ check {err}')
+    sgx_https = SgxClient(SGX_SERVER_URL, SGX_CERTIFICATES_FOLDER)
+    try:
+        if sgx_https.get_server_status() == 0:
+            status_https = True
         if version is None:
-            version = sgx_zmq.zmq.get_server_version()
-    except Exception as e:  # todo: catch specific error - edit sgx.py
-        logger.info(e)
+            version = sgx_https.get_server_version()
+    except Exception as err:
+        logger.error(f'Cannot make SGX HTTPS check {err}')
 
     res = {
         'status_zmq': status_zmq,

--- a/web/routes/health.py
+++ b/web/routes/health.py
@@ -18,8 +18,6 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-import telnetlib
-from enum import Enum
 from http import HTTPStatus
 
 
@@ -27,7 +25,6 @@ from flask import Blueprint, g, request
 from sgx import SgxClient
 
 
-from urllib.parse import urlparse
 from core.node import get_check_report, get_skale_node_version
 from core.node import get_current_nodes
 from core.schains.checks import SChainChecks
@@ -38,7 +35,6 @@ from core.schains.firewall.utils import (
 from core.schains.ima import get_ima_log_checks
 from core.schains.external_config import ExternalState
 from tools.sgx_utils import SGX_CERTIFICATES_FOLDER, SGX_SERVER_URL
-from tools.configs import ZMQ_PORT, ZMQ_TIMEOUT
 from web.models.schain import SChainRecord
 from web.helper import (
     construct_err_response,


### PR DESCRIPTION
ZeroMQ SGX connection check was added to existing SGX check.

**Usage:**
`$ curl http://YOUR_SKALE_NODE_IP:3009/status/sgx`

**Old response:**
`{"data": {"status": 0, "status_name": "CONNECTED", "sgx_wallet_version": "1.9.0"}, "error": null}`

**New response:**
`{"data": {"status_zmq": true, "status_https": true, "sgx_wallet_version": "1.9.0"}, "error": null}`

No performance related changes were introduced. 
No additional tests needed.