### PR TITLE
Revert back to utcfromtimestamp in update_repair_ts, update tests

### DIFF
--- a/core/schains/monitor/action.py
+++ b/core/schains/monitor/action.py
@@ -540,5 +540,5 @@ class SkaledActionManager(BaseActionManager):
     @BaseActionManager.monitor_block
     def update_repair_ts(self, new_ts: int) -> None:
         logger.info('Setting repair_ts to %d', new_ts)
-        new_dt = datetime.fromtimestamp(new_ts, tz=timezone.utc)
+        new_dt = datetime.utcfromtimestamp(new_ts)
         self.schain_record.set_repair_date(new_dt)

--- a/core/schains/monitor/action.py
+++ b/core/schains/monitor/action.py
@@ -19,7 +19,7 @@
 
 import logging
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 from functools import wraps
 from typing import Dict, Optional, List
 

--- a/tests/schains/monitor/action/skaled_action_test.py
+++ b/tests/schains/monitor/action/skaled_action_test.py
@@ -20,7 +20,7 @@ from web.models.schain import SChainRecord
 from tests.utils import IMA_MIGRATION_TS
 
 CURRENT_TIMESTAMP = 1594903080
-CURRENT_DATETIME = datetime.datetime.fromtimestamp(CURRENT_TIMESTAMP)
+CURRENT_DATETIME = datetime.datetime.utcfromtimestamp(CURRENT_TIMESTAMP)
 
 
 def run_ima_container_mock(
@@ -473,4 +473,4 @@ def test_update_repair_ts(skaled_am):
     assert skaled_am.schain_record.repair_mode
     skaled_am.update_repair_ts(CURRENT_TIMESTAMP)
     repair_date = skaled_am.schain_record.repair_date
-    assert datetime.datetime.fromisoformat(repair_date).timestamp() == CURRENT_TIMESTAMP
+    assert repair_date.timestamp() == CURRENT_TIMESTAMP


### PR DESCRIPTION
In this PR:

- Reverted ts changes in `update_repair_ts` to use deprecated `utcfromtimestamp` method

Should be fixed after #1172 