### PR TITLE
Remove Resource Restrictions for Mirage Nodes in skale-admin

### DIFF
--- a/core/schains/monitor/containers.py
+++ b/core/schains/monitor/containers.py
@@ -37,7 +37,7 @@ from core.schains.runner import (
 from core.schains.ima import get_ima_time_frame, ImaData
 from core.schains.ssl import update_ssl_change_date
 
-from tools.configs import SYNC_NODE
+from tools.configs import SYNC_NODE, SKALE_NETWORK_TYPE
 from tools.configs.containers import MAX_SCHAIN_RESTART_COUNT, SCHAIN_CONTAINER, IMA_CONTAINER
 from tools.docker_utils import DockerUtils
 
@@ -110,7 +110,7 @@ def monitor_schain_container(
 def monitor_ima_container(
     schain: dict, ima_data: ImaData, migration_ts: int = 0, dutils: DockerUtils = None
 ) -> None:
-    if SYNC_NODE:
+    if SYNC_NODE or SKALE_NETWORK_TYPE == 'mirage':
         return
 
     if not ima_data.linked:

--- a/core/schains/runner.py
+++ b/core/schains/runner.py
@@ -49,6 +49,7 @@ from tools.configs import (
     SKALE_DIR_HOST,
     SKALE_VOLUME_PATH,
     SCHAIN_CONFIG_DIR_SKALED,
+    SKALE_NETWORK_TYPE,
 )
 
 
@@ -197,8 +198,12 @@ def run_schain_container(
     schain_name = schain.name
     schain_type = get_schain_type(schain.part_of_node)
 
-    cpu_limit = None if sync_node else get_schain_limit(schain_type, MetricType.cpu_shares)
-    mem_limit = None if sync_node else get_schain_limit(schain_type, MetricType.mem)
+    if sync_node or SKALE_NETWORK_TYPE == 'mirage':
+        cpu_limit = None
+        mem_limit = None
+    else:
+        cpu_limit = get_schain_limit(schain_type, MetricType.cpu_shares)
+        mem_limit = get_schain_limit(schain_type, MetricType.mem)
 
     volume_config = get_schain_volume_config(
         schain_name, DATA_DIR_CONTAINER_PATH, mode=volume_mode, sync_node=sync_node

--- a/core/schains/volume.py
+++ b/core/schains/volume.py
@@ -24,6 +24,7 @@ import shutil
 from skale.contracts.manager.schains import SchainStructure
 from core.schains.limits import get_schain_limit, get_schain_type
 from core.schains.types import MetricType
+from tools.configs import SKALE_NETWORK_TYPE
 from tools.configs.schains import SCHAIN_STATE_PATH, SCHAIN_STATIC_PATH
 from tools.configs.containers import SHARED_SPACE_VOLUME_NAME, SHARED_SPACE_CONTAINER_PATH
 
@@ -34,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 def is_volume_exists(schain_name, sync_node=False, dutils=None):
     dutils = dutils or DockerUtils()
-    if sync_node:
+    if sync_node or SKALE_NETWORK_TYPE == 'mirage':
         schain_state = os.path.join(SCHAIN_STATE_PATH, schain_name)
         schain_static_path = os.path.join(SCHAIN_STATIC_PATH, schain_name)
         return os.path.isdir(schain_state) and os.path.islink(schain_static_path)
@@ -50,7 +51,7 @@ def init_data_volume(schain: SchainStructure, sync_node: bool = False, dutils: D
         return
 
     logger.info(f'Creating volume for schain: {schain.name}')
-    if sync_node:
+    if sync_node or SKALE_NETWORK_TYPE == 'mirage':
         ensure_data_dir_path(schain.name)
     else:
         schain_type = get_schain_type(schain.part_of_node)
@@ -77,7 +78,7 @@ def ensure_data_dir_path(schain_name: str) -> None:
 
 def get_schain_volume_config(name, mount_path, mode=None, sync_node=False):
     mode = mode or 'rw'
-    if sync_node:
+    if sync_node or SKALE_NETWORK_TYPE == 'mirage':
         datadir_src = os.path.join(SCHAIN_STATE_PATH, name)
         shared_space_src = os.path.join(SCHAIN_STATE_PATH, SHARED_SPACE_VOLUME_NAME)
     else:

--- a/tools/configs/__init__.py
+++ b/tools/configs/__init__.py
@@ -81,6 +81,7 @@ META_FILEPATH = os.path.join(NODE_DATA_PATH, 'meta.json')
 ALLOWED_TIMESTAMP_DIFF = int(os.getenv('ALLOWED_TIMESTAMP_DIFF', 120))
 
 ENV_TYPE = os.environ.get('ENV_TYPE')
+SKALE_NETWORK_TYPE = os.environ.get('SKALE_NETWORK_TYPE')
 ALLOCATION_FILEPATH = os.path.join(CONFIG_FOLDER, 'schain_allocation.yml')
 
 STATIC_PARAMS_FILEPATH = os.path.join(CONFIG_FOLDER, 'static_params.yaml')
@@ -108,3 +109,5 @@ DOCKER_NODE_CONFIG_FILEPATH = os.path.join(NODE_DATA_PATH, 'docker.json')
 
 NFT_CHAIN_BASE_PATH = '/etc/nft.conf.d/skale/chains'
 NFT_CHAIN_CONFIG_WILDCARD = os.path.join(NFT_CHAIN_BASE_PATH, '*')
+
+MIRAGE_CHAIN_NAME = 'mirage'


### PR DESCRIPTION
## Problem

Default CPU, memory, and disk resource limits applied by `skale-admin` are unnecessary for Mirage nodes.

## Solution

This pull request introduces a `SKALE_NETWORK_TYPE` environment variable.
When this variable is set to 'mirage', `skale-admin` will:

* Remove CPU and memory limitations for `skaled` containers.
* Adjust SKALE chain volume handling to be consistent with sync nodes, thereby removing specific disk restrictions.
* Bypass IMA (Interchain Messaging Agent) container monitoring.

This allows Mirage nodes to operate with fewer resource constraints, tailored to their specific needs.

## Benefits

* **Optimized Resource Use for Mirage:** Enables Mirage nodes to utilize system resources without the default `skale-admin` limitations.
* **Simplified Configuration:** Provides a straightforward way to differentiate behavior for Mirage nodes via an environment variable.

## Testing

* The changes have been validated using the existing test suite.

## Reviewer Instructions

1.  **Verify Mirage Node Behavior:**
    * Set the `SKALE_NETWORK_TYPE` environment variable to 'mirage'.
    * Confirm that `skaled` containers are launched without CPU/memory limits.
    * Ensure SKALE chain volume configuration and IMA monitoring behavior match the described changes for Mirage nodes.

2.  **Verify Default Behavior:**
    * Ensure that with `SKALE_NETWORK_TYPE` unset or set to a different value, `skale-admin` maintains its standard resource limiting and IMA monitoring behavior.