### PR TITLE
Fix filestorage maaping mirage - skip filestorage

### DIFF
--- a/core/config/schain/generator.py
+++ b/core/config/schain/generator.py
@@ -49,9 +49,8 @@ from core.config.base_config import SChainConfig, MirageConfig, SChainBaseConfig
 
 from core.config.mirage.generator import generate_mirage_config_adapter
 
-from tools.configs import SKALE_NETWORK_TYPE
 from tools.configs.schains import BASE_SCHAIN_CONFIG_FILEPATH
-from tools.helper import is_zero_address, is_address_contract
+from tools.helper import is_mirage, is_zero_address, is_address_contract
 from tools.node_options import NodeOptions
 
 
@@ -256,7 +255,7 @@ def generate_schain_config_with_skale(
     else:
         schain_base_port = get_schain_base_port_on_node(schains_on_node, schain.name, node['port'])
 
-    if SKALE_NETWORK_TYPE == 'mirage':
+    if is_mirage():
         return generate_mirage_config_adapter(
             skale_node=node,
             node_id=NodeId(node_config.id),

--- a/core/schains/monitor/containers.py
+++ b/core/schains/monitor/containers.py
@@ -37,9 +37,10 @@ from core.schains.runner import (
 from core.schains.ima import get_ima_time_frame, ImaData
 from core.schains.ssl import update_ssl_change_date
 
-from tools.configs import SYNC_NODE, SKALE_NETWORK_TYPE
+from tools.configs import SYNC_NODE
 from tools.configs.containers import MAX_SCHAIN_RESTART_COUNT, SCHAIN_CONTAINER, IMA_CONTAINER
 from tools.docker_utils import DockerUtils
+from tools.helper import is_mirage
 
 
 logger = logging.getLogger(__name__)
@@ -110,7 +111,7 @@ def monitor_schain_container(
 def monitor_ima_container(
     schain: dict, ima_data: ImaData, migration_ts: int = 0, dutils: DockerUtils = None
 ) -> None:
-    if SYNC_NODE or SKALE_NETWORK_TYPE == 'mirage':
+    if SYNC_NODE or is_mirage():
         return
 
     if not ima_data.linked:

--- a/core/schains/runner.py
+++ b/core/schains/runner.py
@@ -33,6 +33,7 @@ from core.config.schain.helper import get_schain_env
 from core.schains.ima import get_ima_env
 from core.config.schain.directory import schain_config_dir_host
 from tools.docker_utils import DockerUtils
+from tools.helper import is_mirage
 from tools.str_formatters import arguments_list_string
 from tools.configs.containers import (
     CONTAINER_NAME_PREFIX,
@@ -49,7 +50,6 @@ from tools.configs import (
     SKALE_DIR_HOST,
     SKALE_VOLUME_PATH,
     SCHAIN_CONFIG_DIR_SKALED,
-    SKALE_NETWORK_TYPE,
 )
 
 
@@ -198,7 +198,7 @@ def run_schain_container(
     schain_name = schain.name
     schain_type = get_schain_type(schain.part_of_node)
 
-    if sync_node or SKALE_NETWORK_TYPE == 'mirage':
+    if sync_node or is_mirage():
         cpu_limit = None
         mem_limit = None
     else:

--- a/core/schains/volume.py
+++ b/core/schains/volume.py
@@ -24,18 +24,18 @@ import shutil
 from skale.contracts.manager.schains import SchainStructure
 from core.schains.limits import get_schain_limit, get_schain_type
 from core.schains.types import MetricType
-from tools.configs import SKALE_NETWORK_TYPE
 from tools.configs.schains import SCHAIN_STATE_PATH, SCHAIN_STATIC_PATH
 from tools.configs.containers import SHARED_SPACE_VOLUME_NAME, SHARED_SPACE_CONTAINER_PATH
 
 from tools.docker_utils import DockerUtils
+from tools.helper import is_mirage
 
 logger = logging.getLogger(__name__)
 
 
 def is_volume_exists(schain_name, sync_node=False, dutils=None):
     dutils = dutils or DockerUtils()
-    if sync_node or SKALE_NETWORK_TYPE == 'mirage':
+    if sync_node or is_mirage():
         schain_state = os.path.join(SCHAIN_STATE_PATH, schain_name)
         schain_static_path = os.path.join(SCHAIN_STATIC_PATH, schain_name)
         return os.path.isdir(schain_state) and os.path.islink(schain_static_path)
@@ -51,7 +51,7 @@ def init_data_volume(schain: SchainStructure, sync_node: bool = False, dutils: D
         return
 
     logger.info(f'Creating volume for schain: {schain.name}')
-    if sync_node or SKALE_NETWORK_TYPE == 'mirage':
+    if sync_node or is_mirage():
         ensure_data_dir_path(schain.name)
     else:
         schain_type = get_schain_type(schain.part_of_node)
@@ -69,16 +69,17 @@ def remove_data_dir(schain_name):
 def ensure_data_dir_path(schain_name: str) -> None:
     schain_state = os.path.join(SCHAIN_STATE_PATH, schain_name)
     os.makedirs(schain_state, exist_ok=True)
-    schain_filestorage_state = os.path.join(schain_state, 'filestorage')
-    schain_static_path = os.path.join(SCHAIN_STATIC_PATH, schain_name)
-    if os.path.islink(schain_static_path):
-        os.unlink(schain_static_path)
-    os.symlink(schain_filestorage_state, schain_static_path, target_is_directory=True)
+    if not is_mirage():
+        schain_filestorage_state = os.path.join(schain_state, 'filestorage')
+        schain_static_path = os.path.join(SCHAIN_STATIC_PATH, schain_name)
+        if os.path.islink(schain_static_path):
+            os.unlink(schain_static_path)
+        os.symlink(schain_filestorage_state, schain_static_path, target_is_directory=True)
 
 
 def get_schain_volume_config(name, mount_path, mode=None, sync_node=False):
     mode = mode or 'rw'
-    if sync_node or SKALE_NETWORK_TYPE == 'mirage':
+    if sync_node or is_mirage():
         datadir_src = os.path.join(SCHAIN_STATE_PATH, name)
         shared_space_src = os.path.join(SCHAIN_STATE_PATH, SHARED_SPACE_VOLUME_NAME)
     else:

--- a/core/schains/volume.py
+++ b/core/schains/volume.py
@@ -19,12 +19,11 @@
 
 import logging
 import os
-import shutil
 
 from skale.contracts.manager.schains import SchainStructure
 from core.schains.limits import get_schain_limit, get_schain_type
 from core.schains.types import MetricType
-from tools.configs.schains import SCHAIN_STATE_PATH, SCHAIN_STATIC_PATH
+from tools.configs.schains import SCHAIN_STATE_PATH, FILESTORAGE_STATIC_PATH
 from tools.configs.containers import SHARED_SPACE_VOLUME_NAME, SHARED_SPACE_CONTAINER_PATH
 
 from tools.docker_utils import DockerUtils
@@ -35,10 +34,13 @@ logger = logging.getLogger(__name__)
 
 def is_volume_exists(schain_name, sync_node=False, dutils=None):
     dutils = dutils or DockerUtils()
-    if sync_node or is_mirage():
-        schain_state = os.path.join(SCHAIN_STATE_PATH, schain_name)
-        schain_static_path = os.path.join(SCHAIN_STATIC_PATH, schain_name)
-        return os.path.isdir(schain_state) and os.path.islink(schain_static_path)
+
+    schain_state = os.path.join(SCHAIN_STATE_PATH, schain_name)
+    if sync_node:
+        filestorage_static_path_schain = os.path.join(FILESTORAGE_STATIC_PATH, schain_name)
+        return os.path.isdir(schain_state) and os.path.islink(filestorage_static_path_schain)
+    elif is_mirage():
+        return os.path.isdir(schain_state)
     else:
         return dutils.is_data_volume_exists(schain_name)
 
@@ -59,22 +61,17 @@ def init_data_volume(schain: SchainStructure, sync_node: bool = False, dutils: D
         dutils.create_data_volume(schain.name, disk_limit)
 
 
-def remove_data_dir(schain_name):
-    schain_state = os.path.join(SCHAIN_STATE_PATH, schain_name)
-    schain_static_path = os.path.join(SCHAIN_STATIC_PATH, schain_name)
-    os.remove(schain_static_path)
-    shutil.rmtree(schain_state)
-
-
 def ensure_data_dir_path(schain_name: str) -> None:
     schain_state = os.path.join(SCHAIN_STATE_PATH, schain_name)
     os.makedirs(schain_state, exist_ok=True)
     if not is_mirage():
         schain_filestorage_state = os.path.join(schain_state, 'filestorage')
-        schain_static_path = os.path.join(SCHAIN_STATIC_PATH, schain_name)
-        if os.path.islink(schain_static_path):
-            os.unlink(schain_static_path)
-        os.symlink(schain_filestorage_state, schain_static_path, target_is_directory=True)
+        filestorage_static_path_schain = os.path.join(FILESTORAGE_STATIC_PATH, schain_name)
+        if os.path.islink(filestorage_static_path_schain):
+            os.unlink(filestorage_static_path_schain)
+        os.symlink(
+            schain_filestorage_state, filestorage_static_path_schain, target_is_directory=True
+        )
 
 
 def get_schain_volume_config(name, mount_path, mode=None, sync_node=False):

--- a/tools/configs/schains.py
+++ b/tools/configs/schains.py
@@ -52,7 +52,7 @@ NODE_CLI_STATUS_FILENAME = 'node_cli.status'
 
 STATIC_SCHAIN_DIR_NAME = 'schains'
 SCHAIN_STATE_PATH = os.path.join(SKALE_LIB_PATH, 'schains')
-SCHAIN_STATIC_PATH = os.path.join(SKALE_LIB_PATH, 'filestorage')
+FILESTORAGE_STATIC_PATH = os.path.join(SKALE_LIB_PATH, 'filestorage')
 
 DEFAULT_RPC_CHECK_TIMEOUT = 30
 RPC_CHECK_TIMEOUT_STEP = 10

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -33,7 +33,7 @@ from jinja2 import Environment
 from skale import SkaleManager
 from skale.wallets import BaseWallet
 
-from tools.configs import INIT_LOCK_PATH
+from tools.configs import INIT_LOCK_PATH, SKALE_NETWORK_TYPE
 from tools.configs.web3 import ENDPOINT, MANAGER_CONTRACTS, STATE_FILEPATH, ZERO_ADDRESS
 
 
@@ -182,3 +182,7 @@ def is_address_contract(web3, address) -> bool:
 
 def no_hyphens(name: str) -> str:
     return name.replace('-', '_')
+
+
+def is_mirage() -> bool:
+    return SKALE_NETWORK_TYPE == 'mirage'


### PR DESCRIPTION
In this PR:

- Moved mirage node check to the separate function
- Added a condition in filestorage mapping: skip for mirage
- Renamed filestorage path variables
- Removed unused function (`remove_data_dir`)

No test updates.