### PR TITLE
Configure Mirage Chain Parameters from Static File & Allow QA Account Overrides

### DIFF
--- a/core/config/mirage/generator.py
+++ b/core/config/mirage/generator.py
@@ -35,6 +35,7 @@ from core.config.schain.static_params import (
     get_static_schain_info_mirage,
     get_static_node_info_mirage,
 )
+from core.config.schain.static_params import get_static_chain_id_mirage
 
 from tools.configs.schains import MIRAGE_BASE_SCHAIN_CONFIG_FILEPATH
 
@@ -56,10 +57,6 @@ class MirageSkaleConfig:
 def generate_mirage_config_with_manager() -> None:
     """Will be implemented in the future"""
     pass
-
-
-def get_mirage_chain_id() -> str:
-    return '0x3A6'  # TODO: Replace with actual logic to get the chain ID (or move to config file)
 
 
 def skale_node_to_mirage_node_adapter(skale_node: SkaleNode, node_id: NodeId) -> MirageNode:
@@ -119,7 +116,7 @@ def generate_mirage_config(
     logger.info('Generating Mirage config...')
     base_config = SChainBaseConfig(MIRAGE_BASE_SCHAIN_CONFIG_FILEPATH)
 
-    chain_id = get_mirage_chain_id()
+    chain_id = get_static_chain_id_mirage()
     chain_id_int = int(chain_id, 16)
 
     dynamic_params = {'chainID': chain_id}

--- a/core/config/mirage/generator.py
+++ b/core/config/mirage/generator.py
@@ -117,6 +117,7 @@ def generate_mirage_config(
     base_config = SChainBaseConfig(MIRAGE_BASE_SCHAIN_CONFIG_FILEPATH)
 
     chain_id = get_static_chain_id_mirage()
+    chain_id_int = int(chain_id, 16)
 
     dynamic_params = {'chainID': chain_id}
     accounts = {
@@ -133,7 +134,7 @@ def generate_mirage_config(
     )
 
     schain_info = MirageChainInfo(
-        schain_id=chain_id,
+        schain_id=chain_id_int,
         node_groups=node_groups,
         nodes=chain_nodes,
         static_schain_info=static_schain_info,

--- a/core/config/mirage/generator.py
+++ b/core/config/mirage/generator.py
@@ -117,10 +117,12 @@ def generate_mirage_config(
     base_config = SChainBaseConfig(MIRAGE_BASE_SCHAIN_CONFIG_FILEPATH)
 
     chain_id = get_static_chain_id_mirage()
-    chain_id_int = int(chain_id, 16)
 
     dynamic_params = {'chainID': chain_id}
-    accounts = get_precompiled_contracts_mirage()
+    accounts = {
+        **base_config.config['accounts'],
+        **get_precompiled_contracts_mirage(),
+    }
 
     static_schain_info = get_static_schain_info_mirage()
 
@@ -131,7 +133,7 @@ def generate_mirage_config(
     )
 
     schain_info = MirageChainInfo(
-        schain_id=chain_id_int,
+        schain_id=chain_id,
         node_groups=node_groups,
         nodes=chain_nodes,
         static_schain_info=static_schain_info,

--- a/core/config/mirage/mirage_schain_node.py
+++ b/core/config/mirage/mirage_schain_node.py
@@ -24,7 +24,7 @@ from skale.utils.helper import ip_from_bytes
 from skale.types.node import MirageNode
 
 from core.config.schain.helper import parse_public_key_info, get_bls_public_keys
-from tools.configs import MIRAGE_CHAIN_NAME
+from core.config.schain.static_params import get_static_chain_name_mirage
 
 
 @dataclass
@@ -57,7 +57,7 @@ def generate_mirage_chain_nodes(
     if sync_node:
         bls_public_keys = ['0:0:1:0'] * len(committee_nodes)
     else:
-        bls_public_keys = get_bls_public_keys(MIRAGE_CHAIN_NAME, rotation_id)
+        bls_public_keys = get_bls_public_keys(get_static_chain_name_mirage(), rotation_id)
 
     for i, node in enumerate(committee_nodes, 1):
         node_info = MirageChainNodeInfo(

--- a/core/config/mirage/node_info.py
+++ b/core/config/mirage/node_info.py
@@ -23,9 +23,10 @@ from dataclasses import dataclass
 from skale.types.node import NodeId, Port
 from skale.dataclasses.node_info import NodeInfo
 
-from tools.configs import MIRAGE_CHAIN_NAME, SGX_SSL_KEY_FILEPATH, SGX_SSL_CERT_FILEPATH
-
 from core.schains.dkg.utils import get_secret_key_share_filepath
+from core.config.schain.static_params import get_static_chain_name_mirage
+
+from tools.configs import SGX_SSL_KEY_FILEPATH, SGX_SSL_CERT_FILEPATH
 from tools.helper import read_json
 
 
@@ -111,7 +112,9 @@ def generate_mirage_wallets_config(
     wallets['ima'].update({'n': nodes_in_chain, **formatted_common_pk})
 
     if not sync_node:
-        secret_key_share_filepath = get_secret_key_share_filepath(MIRAGE_CHAIN_NAME, group_index)
+        secret_key_share_filepath = get_secret_key_share_filepath(
+            get_static_chain_name_mirage(), group_index
+        )
         secret_key_share_config = read_json(secret_key_share_filepath)
 
         wallets['ima'].update(

--- a/core/config/mirage/schain_info.py
+++ b/core/config/mirage/schain_info.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from typing import Dict
 from skale.types.rotation import NodesGroup
 from core.config.mirage.mirage_schain_node import MirageChainNodeInfo
-from tools.configs import MIRAGE_CHAIN_NAME
+from core.config.schain.static_params import get_static_chain_name_mirage
 from tools.configs.schains import MAX_HISTORIC_STATE_DB_SIZE
 
 
@@ -38,7 +38,7 @@ class MirageChainInfo:
     def to_dict(self):
         data = {
             'schainID': self.schain_id,
-            'schainName': MIRAGE_CHAIN_NAME,
+            'schainName': get_static_chain_name_mirage(),
             'nodeGroups': self.node_groups,
             'multiTransactionMode': True,
             'nodes': self.nodes,

--- a/core/config/schain/static_params.py
+++ b/core/config/schain/static_params.py
@@ -24,12 +24,12 @@ from tools.configs import ENV_TYPE
 
 def get_static_chain_id_mirage(env_type: str = ENV_TYPE):
     static_params = get_static_params_mirage(env_type)
-    return static_params['info']['chainId']
+    return static_params['info']['chain_id']
 
 
 def get_static_chain_name_mirage(env_type: str = ENV_TYPE) -> str:
     static_params = get_static_params_mirage(env_type)
-    return static_params['info']['chainName']
+    return static_params['info']['chain_name']
 
 
 def get_static_skaled_cmd_mirage(env_type: str = ENV_TYPE) -> list:

--- a/core/config/schain/static_params.py
+++ b/core/config/schain/static_params.py
@@ -22,12 +22,12 @@ from core.config.schain.helper import get_static_params, get_static_params_mirag
 from tools.configs import ENV_TYPE
 
 
-def get_static_chain_id_mirage(env_type: str = ENV_TYPE) -> list:
+def get_static_chain_id_mirage(env_type: str = ENV_TYPE):
     static_params = get_static_params_mirage(env_type)
     return static_params['info']['chainId']
 
 
-def get_static_chain_name_mirage(env_type: str = ENV_TYPE) -> list:
+def get_static_chain_name_mirage(env_type: str = ENV_TYPE) -> str:
     static_params = get_static_params_mirage(env_type)
     return static_params['info']['chainName']
 

--- a/core/config/schain/static_params.py
+++ b/core/config/schain/static_params.py
@@ -22,6 +22,16 @@ from core.config.schain.helper import get_static_params, get_static_params_mirag
 from tools.configs import ENV_TYPE
 
 
+def get_static_chain_id_mirage(env_type: str = ENV_TYPE) -> list:
+    static_params = get_static_params_mirage(env_type)
+    return static_params['info']['chainId']
+
+
+def get_static_chain_name_mirage(env_type: str = ENV_TYPE) -> list:
+    static_params = get_static_params_mirage(env_type)
+    return static_params['info']['chainName']
+
+
 def get_static_skaled_cmd_mirage(env_type: str = ENV_TYPE) -> list:
     static_params = get_static_params_mirage(env_type)
     return static_params['skaled_cmd']

--- a/core/config/schain/static_params.py
+++ b/core/config/schain/static_params.py
@@ -17,12 +17,14 @@
 #   You should have received a copy of the GNU Affero General Public License
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from eth_typing import HexStr
+
 from core.schains.types import SchainType
 from core.config.schain.helper import get_static_params, get_static_params_mirage
 from tools.configs import ENV_TYPE
 
 
-def get_static_chain_id_mirage(env_type: str = ENV_TYPE):
+def get_static_chain_id_mirage(env_type: str = ENV_TYPE) -> HexStr:
     static_params = get_static_params_mirage(env_type)
     return static_params['info']['chain_id']
 

--- a/tests/mirage/config_test.py
+++ b/tests/mirage/config_test.py
@@ -31,7 +31,7 @@ MIRAGE_TEST_SECRET_KEY = {
 @pytest.fixture
 def mirage_secret_key_file():
     """Creates a dummy secret_key_0.json specifically for mirage tests."""
-    schain_name = 'mirage'
+    schain_name = 'mirage-devnet'
     schain_dir = os.path.join(SCHAINS_DIR_PATH, schain_name)
     secret_key_path = os.path.join(schain_dir, 'secret_key_0.json')
 
@@ -160,7 +160,7 @@ def test_generate_mirage_config_adapter(mirage_secret_key_file, node_groups):
 
     assert isinstance(config, MirageConfig)
     config_dict = config.to_dict()
-    assert config_dict['params']['chainID'] == '0x3A6'
+    assert config_dict['params']['chainID'] == 936
 
 
 def test_generate_mirage_config_minimal_regular(mirage_secret_key_file, mirage_node, node_groups):
@@ -197,7 +197,7 @@ def test_generate_mirage_config_minimal_regular(mirage_secret_key_file, mirage_n
     assert isinstance(config, MirageConfig)
     config_dict = config.to_dict()
 
-    assert config_dict['params']['chainID'] == '0x3A6'
+    assert config_dict['params']['chainID'] == 936
     assert 'skaleConfig' in config_dict
     assert 'contractSettings' not in config_dict['skaleConfig']
 
@@ -211,7 +211,7 @@ def test_generate_mirage_config_minimal_regular(mirage_secret_key_file, mirage_n
     assert node_info['wallets']['ima']['BLSPublicKey0'] == node_bls_keys_for_node_info[0]
 
     schain_info = config_dict['skaleConfig']['sChain']
-    assert schain_info['schainID'] == int('0x3A6', 16)
+    assert schain_info['schainID'] == 936
     assert schain_info['multiTransactionMode'] is True
     assert 'nodes' in schain_info
 

--- a/tests/mirage/config_test.py
+++ b/tests/mirage/config_test.py
@@ -2,6 +2,7 @@ import pytest
 import mock
 import os
 import json
+import contextlib
 from pathlib import Path
 from typing import Dict, cast
 
@@ -9,6 +10,7 @@ from eth_typing import BlockNumber, HexStr, ChecksumAddress
 
 from core.config.mirage.generator import generate_mirage_config, generate_mirage_config_adapter
 from core.config.base_config import MirageConfig
+from core.config.schain.helper import get_static_params_mirage as original_get_static_params_mirage
 
 from skale.types.rotation import Rotation, NodesGroup, RotationNodeData, NodesSwap
 from skale.types.node import Node, NodeId, NodeStatus, Port, MirageNode, NodeWithSchains
@@ -17,6 +19,7 @@ from skale.contracts.manager.schains import SchainStructure
 
 from tools.configs.schains import SCHAINS_DIR_PATH
 from tools.configs.web3 import ZERO_ADDRESS
+from tools.configs import MIRAGE_STATIC_PARAMS_FILEPATH
 
 MIRAGE_TEST_SECRET_KEY = {
     'key_share_name': 'BLS_KEY:SCHAIN_ID:MIRAGE:NODE_ID:0:DKG_ID:0',
@@ -28,9 +31,33 @@ MIRAGE_TEST_SECRET_KEY = {
 }
 
 
+@contextlib.contextmanager
+def create_dynamic_secret_key_file(chain_name_for_path: str):
+    """Context manager to create and clean up a dummy secret_key_0.json."""
+    schain_dir = os.path.join(SCHAINS_DIR_PATH, chain_name_for_path)
+    secret_key_path = os.path.join(schain_dir, 'secret_key_0.json')
+
+    Path(schain_dir).mkdir(parents=True, exist_ok=True)
+    with open(secret_key_path, 'w') as f:
+        json.dump(MIRAGE_TEST_SECRET_KEY, f)
+    try:
+        yield secret_key_path
+    finally:
+        if os.path.exists(secret_key_path):
+            os.remove(secret_key_path)
+        try:
+            if not os.listdir(schain_dir):
+                os.rmdir(schain_dir)
+        except OSError:
+            pass
+
+
 @pytest.fixture
-def mirage_secret_key_file():
-    """Creates a dummy secret_key_0.json specifically for mirage tests."""
+def mirage_default_secret_key_file():
+    """
+    Creates a dummy secret_key_0.json specifically for mirage tests.
+    Assumes env is exported devnet.
+    """
     schain_name = 'mirage-devnet'
     schain_dir = os.path.join(SCHAINS_DIR_PATH, schain_name)
     secret_key_path = os.path.join(schain_dir, 'secret_key_0.json')
@@ -78,7 +105,7 @@ def node_groups() -> Dict[int, NodesGroup]:
     }
 
 
-def test_generate_mirage_config_adapter(mirage_secret_key_file, node_groups):
+def test_generate_mirage_config_adapter(mirage_default_secret_key_file, node_groups):
     mock_schain = mock.MagicMock(spec=SchainStructure)
     mock_schain.name = 'mirage'
     mock_schain.part_of_node = 1
@@ -160,14 +187,12 @@ def test_generate_mirage_config_adapter(mirage_secret_key_file, node_groups):
 
     assert isinstance(config, MirageConfig)
     config_dict = config.to_dict()
-    assert config_dict['params']['chainID'] == 936
+    assert config_dict['params']['chainID'] == '0x3A8'
 
 
-def test_generate_mirage_config_minimal_regular(mirage_secret_key_file, mirage_node, node_groups):
-    mock_schain = mock.MagicMock(spec=SchainStructure)
-    mock_schain.name = 'mirage'
-    mock_schain.part_of_node = 1
-
+def test_generate_mirage_config_minimal_regular(
+    mirage_default_secret_key_file, mirage_node, node_groups
+):
     mock_rotation = mock.MagicMock(spec=Rotation)
     mock_rotation.rotation_counter = 0
     mock_rotation.freeze_until = 1700000000
@@ -197,7 +222,7 @@ def test_generate_mirage_config_minimal_regular(mirage_secret_key_file, mirage_n
     assert isinstance(config, MirageConfig)
     config_dict = config.to_dict()
 
-    assert config_dict['params']['chainID'] == 936
+    assert config_dict['params']['chainID'] == '0x3A8'
     assert 'skaleConfig' in config_dict
     assert 'contractSettings' not in config_dict['skaleConfig']
 
@@ -222,11 +247,9 @@ def test_generate_mirage_config_minimal_regular(mirage_secret_key_file, mirage_n
     assert node_list[0]['owner'].startswith('0x')
 
 
-def test_generate_mirage_config_minimal_sync(mirage_secret_key_file, mirage_node, node_groups):
-    mock_schain = mock.MagicMock(spec=SchainStructure)
-    mock_schain.name = 'mirage'
-    mock_schain.part_of_node = 1
-
+def test_generate_mirage_config_minimal_sync(
+    mirage_default_secret_key_file, mirage_node, node_groups
+):
     mock_rotation = mock.MagicMock(spec=Rotation)
     mock_rotation.rotation_counter = 0
     mock_rotation.freeze_until = 1700000000
@@ -262,3 +285,65 @@ def test_generate_mirage_config_minimal_sync(mirage_secret_key_file, mirage_node
     assert 'keyShareName' not in wallets
     assert 't' not in wallets
     assert 'BLSPublicKey0' not in wallets
+
+
+@pytest.mark.parametrize(
+    'current_env_type, expected_chain_id_hex, expected_chain_id_int, expected_chain_name',
+    [
+        ('mainnet', '0x3A6', 934, 'mirage'),
+        ('testnet', '0x3A7', 935, 'mirage-testnet'),
+        ('qanet', '0x3A9', 937, 'mirage-qa'),
+        ('devnet', '0x3A8', 936, 'mirage-devnet'),
+    ],
+)
+def test_generate_mirage_config_for_different_env_types(
+    current_env_type,
+    expected_chain_id_hex,
+    expected_chain_id_int,
+    expected_chain_name,
+    mirage_node,
+    node_groups,
+):
+    mock_rotation = mock.MagicMock(spec=Rotation)
+    mock_rotation.rotation_counter = 0
+    mock_rotation.freeze_until = 1700000000
+
+    common_bls_keys = ['0xA', '0xB']
+
+    committee_nodes = [
+        mirage_node,
+        mirage_node,
+    ]
+
+    def replacement_get_static_params_mirage(
+        env_type_arg_passed_by_caller, path_arg_passed_by_caller=MIRAGE_STATIC_PARAMS_FILEPATH
+    ):
+        return original_get_static_params_mirage(
+            env_type=current_env_type, path=path_arg_passed_by_caller
+        )
+
+    with create_dynamic_secret_key_file(expected_chain_name):
+        with mock.patch(
+            'core.config.schain.static_params.get_static_params_mirage',
+            new=replacement_get_static_params_mirage,
+        ):
+            config = generate_mirage_config(
+                node=mirage_node,
+                committee_nodes=committee_nodes,
+                node_groups=node_groups,
+                group_index=mock_rotation.rotation_counter,
+                ecdsa_key_name='NEK:SIMPLE_REGULAR',
+                common_bls_public_keys=common_bls_keys,
+                sync_node=False,
+                archive=False,
+                catchup=False,
+            )
+
+            assert isinstance(config, MirageConfig)
+            config_dict = config.to_dict()
+
+    assert config_dict['params']['chainID'] == expected_chain_id_hex
+
+    assert config_dict['skaleConfig']['sChain']['schainID'] == expected_chain_id_int
+
+    assert config_dict['skaleConfig']['sChain']['schainName'] == expected_chain_name

--- a/tests/skale-data/config/mirage_static_params.yaml
+++ b/tests/skale-data/config/mirage_static_params.yaml
@@ -48,8 +48,8 @@ envs:
       maxOpenLeveldbFiles: 1000
 
     info:
-      chainId: 0x3A6
-      chainName: mirage
+      chain_id: 0x3A6
+      chain_name: mirage
 
   testnet:
     server:
@@ -97,8 +97,8 @@ envs:
       maxOpenLeveldbFiles: 1000
 
     info:
-      chainId: 0x3A7
-      chainName: mirage-testnet
+      chain_id: 0x3A7
+      chain_name: mirage-testnet
 
   qanet:
     server:
@@ -146,8 +146,8 @@ envs:
       maxOpenLeveldbFiles: 1000
 
     info:
-      chainId: 0x3A9
-      chainName: mirage-qa
+      chain_id: 0x3A9
+      chain_name: mirage-qa
 
   devnet:
     server:
@@ -196,5 +196,5 @@ envs:
       maxOpenLeveldbFiles: 1000
 
     info:
-      chainId: 0x3A8
-      chainName: mirage-devnet
+      chain_id: 0x3A8
+      chain_name: mirage-devnet

--- a/tests/skale-data/config/mirage_static_params.yaml
+++ b/tests/skale-data/config/mirage_static_params.yaml
@@ -48,7 +48,7 @@ envs:
       maxOpenLeveldbFiles: 1000
 
     info:
-      chain_id: 0x3A6
+      chain_id: "0x3A6"
       chain_name: mirage
 
   testnet:
@@ -97,7 +97,7 @@ envs:
       maxOpenLeveldbFiles: 1000
 
     info:
-      chain_id: 0x3A7
+      chain_id: "0x3A7"
       chain_name: mirage-testnet
 
   qanet:
@@ -146,7 +146,7 @@ envs:
       maxOpenLeveldbFiles: 1000
 
     info:
-      chain_id: 0x3A9
+      chain_id: "0x3A9"
       chain_name: mirage-qa
 
   devnet:
@@ -196,5 +196,5 @@ envs:
       maxOpenLeveldbFiles: 1000
 
     info:
-      chain_id: 0x3A8
+      chain_id: "0x3A8"
       chain_name: mirage-devnet

--- a/tests/skale-data/config/mirage_static_params.yaml
+++ b/tests/skale-data/config/mirage_static_params.yaml
@@ -12,7 +12,7 @@ envs:
 
     package:
       iptables-persistent: 1.0.4
-      lvm2: 2.02.0
+      lvm2: disabled
       btrfs-progs: 4.15.1
       lsof: "4.89"
       psmisc: 23.1-1
@@ -27,9 +27,8 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      contractStorageLimit: 1000000000000000000
       dbStorageLimit: 1000000000000000000
-      maxConsensusStorageBytes: 1000000000000000000
+      maxConsensusStorageBytes: 759239973273
 
     skaled_cmd: ["-v 2", "--aa no"]
 
@@ -47,6 +46,10 @@ envs:
       transactionQueueLimitBytes: 69206016
       futureTransactionQueueLimitBytes: 140509184
       maxOpenLeveldbFiles: 1000
+
+    info:
+      chainId: 0x3A6
+      chainName: mirage
 
   testnet:
     server:
@@ -58,7 +61,7 @@ envs:
 
     package:
       iptables-persistent: 1.0.4
-      lvm2: 2.02.0
+      lvm2: disabled
       btrfs-progs: 4.15.1
       lsof: "4.89"
       psmisc: 23.1-1
@@ -73,9 +76,8 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      contractStorageLimit: 1000000000000000000
       dbStorageLimit: 1000000000000000000
-      maxConsensusStorageBytes: 1000000000000000000
+      maxConsensusStorageBytes: 79919972352
 
     skaled_cmd: ["-v 2", "--aa no"]
 
@@ -93,6 +95,10 @@ envs:
       transactionQueueLimitBytes: 69206016
       futureTransactionQueueLimitBytes: 140509184
       maxOpenLeveldbFiles: 1000
+
+    info:
+      chainId: 0x3A7
+      chainName: mirage-testnet
 
   qanet:
     server:
@@ -104,7 +110,7 @@ envs:
 
     package:
       iptables-persistent: 1.0.4
-      lvm2: 2.02.0
+      lvm2: disabled
       btrfs-progs: 4.15.1
       lsof: "4.89"
       psmisc: 23.1-1
@@ -119,9 +125,8 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      contractStorageLimit: 1000000000000000000
       dbStorageLimit: 1000000000000000000
-      maxConsensusStorageBytes: 1000000000000000000
+      maxConsensusStorageBytes: 79919972352
 
     skaled_cmd: ["-v 2", "--aa no"]
 
@@ -140,6 +145,10 @@ envs:
       futureTransactionQueueLimitBytes: 140509184
       maxOpenLeveldbFiles: 1000
 
+    info:
+      chainId: 0x3A9
+      chainName: mirage-qa
+
   devnet:
     server:
       cpu_total: 1
@@ -150,7 +159,7 @@ envs:
 
     package:
       iptables-persistent: 1.0.4
-      lvm2: 2.02.0
+      lvm2: disabled
       btrfs-progs: 4.15.1
       lsof: "4.89"
       psmisc: 23.1-1
@@ -165,9 +174,8 @@ envs:
       emptyBlockIntervalMs: 10000
       snapshotDownloadTimeout: 18000
       snapshotDownloadInactiveTimeout: 120
-      contractStorageLimit: 1000000000000000000
       dbStorageLimit: 1000000000000000000
-      maxConsensusStorageBytes: 1000000000000000000
+      maxConsensusStorageBytes: 31967988940
 
     skaled_cmd:
       ["-v 3", "--web3-trace", "--enable-debug-behavior-apis", "--aa no"]
@@ -186,3 +194,7 @@ envs:
       transactionQueueLimitBytes: 69206016
       futureTransactionQueueLimitBytes: 140509184
       maxOpenLeveldbFiles: 1000
+
+    info:
+      chainId: 0x3A8
+      chainName: mirage-devnet

--- a/tools/configs/__init__.py
+++ b/tools/configs/__init__.py
@@ -110,5 +110,3 @@ DOCKER_NODE_CONFIG_FILEPATH = os.path.join(NODE_DATA_PATH, 'docker.json')
 
 NFT_CHAIN_BASE_PATH = '/etc/nft.conf.d/skale/chains'
 NFT_CHAIN_CONFIG_WILDCARD = os.path.join(NFT_CHAIN_BASE_PATH, '*')
-
-MIRAGE_CHAIN_NAME = 'mirage'


### PR DESCRIPTION
## Problem

Mirage node `chain_id` and `chain_name` were hardcoded in `skale-admin`, hindering environment-specific configurations.
QA also lacked an easy way to inject custom accounts for sChain creation testing.

## Solution

1.  **Externalized Mirage Parameters:**
    * `chain_id` and `chain_name` for Mirage nodes are now sourced from `mirage_static_params.yaml` in `skale-node` (via new `get_static_chain_id_mirage`/`get_static_chain_name_mirage` helpers in `skale-admin`), allowing per-environment values.
    * Removed hardcoded `MIRAGE_CHAIN_NAME` constant.

2.  **QA Account Hotfix:**
    * `skale-admin` now merges accounts from `MIRAGE_BASE_SCHAIN_CONFIG_FILEPATH` into the Mirage config, enabling QA to specify test accounts easily.

## Benefits

* **Maintainability:** Simplifies Mirage configuration updates (no `skale-admin` code changes needed).
* **Flexibility:** Enables distinct `chain_id`/`name` per environment and easier QA testing with custom accounts.
* **Reliability:** Reduces risk from hardcoded values.

## Testing

* Updated unit tests in `tests/mirage/config_test.py` to reflect new parameter sourcing.

## Instructions for Reviewers

1.  **Verify Parameter Sourcing:** Ensure Mirage `chain_id` and `chain_name` are fetched from `skale-node`'s static params file.
2.  **Check QA Account Merge:** Confirm accounts from `MIRAGE_BASE_SCHAIN_CONFIG_FILEPATH` are correctly included.
3.  **Test Configuration Generation:** Conceptually or actually, generate a Mirage config for a specific `ENV_TYPE` and verify the `chain_id`/`name` and any QA-specified accounts.