### PR TITLE
Add cast_manager_to_mirage_node_id

### DIFF
--- a/core/checks/mirage.py
+++ b/core/checks/mirage.py
@@ -23,7 +23,6 @@ import os
 from typing import cast
 
 from skale.mirage_manager import MirageManager
-from skale.types.node import NodeId
 
 from core.checks.base import BaseSkaledChecks, CheckRes, IChecks
 from core.config.endpoint import get_base_port_from_config
@@ -42,13 +41,15 @@ from core.redis.chain_record import ChainRecord
 from core.schains.dkg.utils import get_secret_key_share_filepath
 from core.types.chain import MirageChainName
 from tools.resources import get_statsd_client
+from tools.helper import cast_manager_to_mirage_node_id
 
 logger = logging.getLogger(__name__)
 
 
 def get_base_port_from_mirage_manager(mirage: MirageManager, node_config: NodeConfig) -> int:
     # todod: Should be changed after corresponding changes are made in mirage manager.
-    return mirage.nodes.get(cast(NodeId, node_config.id + 1)).port
+    node_id = cast_manager_to_mirage_node_id(node_config.id)
+    return mirage.nodes.get(node_id).port
 
 
 class MirageConfigChecks(IChecks):

--- a/core/config/mirage/generator.py
+++ b/core/config/mirage/generator.py
@@ -27,6 +27,7 @@ from skale.types.rotation import NodesGroup, Rotation
 from skale.types.node import Node as SkaleNode, NodeWithSchains, MirageNode, NodeId
 from skale.utils.web3_utils import public_key_to_address, to_checksum_address
 
+from core.checks.mirage import cast_manager_to_mirage_node_id
 from core.config.base import MirageConfig, SChainBaseConfig
 from core.config.mirage.schain_info import MirageChainInfo
 from core.config.mirage.node_info import MirageCurrentNodeInfo, generate_mirage_current_node_info
@@ -64,7 +65,7 @@ def generate_mirage_config_with_manager(
     archive: bool,
     catchup: bool,
 ) -> MirageConfig:
-    node = mirage.nodes.get(node_id + 1)
+    node = mirage.nodes.get(cast_manager_to_mirage_node_id(node_id))
 
     # todod: get info from mirage_manager
     committee_nodes = []

--- a/core/config/mirage/generator.py
+++ b/core/config/mirage/generator.py
@@ -27,7 +27,6 @@ from skale.types.rotation import NodesGroup, Rotation
 from skale.types.node import Node as SkaleNode, NodeWithSchains, MirageNode, NodeId
 from skale.utils.web3_utils import public_key_to_address, to_checksum_address
 
-from core.checks.mirage import cast_manager_to_mirage_node_id
 from core.config.base import MirageConfig, SChainBaseConfig
 from core.config.mirage.schain_info import MirageChainInfo
 from core.config.mirage.node_info import MirageCurrentNodeInfo, generate_mirage_current_node_info
@@ -40,6 +39,7 @@ from core.config.schain.static_params import (
 from core.config.schain.static_params import get_static_chain_id_mirage
 
 from tools.configs.schains import MIRAGE_BASE_SCHAIN_CONFIG_FILEPATH
+from tools.helper import cast_manager_to_mirage_node_id
 
 logger = logging.getLogger(__name__)
 

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -25,12 +25,14 @@ import psutil
 import subprocess
 import time
 from subprocess import PIPE
+from typing import cast
 
 import requests
 import yaml
 from filelock import FileLock
 from jinja2 import Environment
 from skale import SkaleManager, MirageManager
+from skale.types.node import NodeId
 from skale.wallets import BaseWallet
 
 from tools.configs import INIT_LOCK_PATH, SKALE_NETWORK_TYPE
@@ -200,3 +202,7 @@ def no_hyphens(name: str) -> str:
 
 def is_mirage() -> bool:
     return SKALE_NETWORK_TYPE == 'mirage'
+
+
+def cast_manager_to_mirage_node_id(manager_node_id: int) -> NodeId:
+    return cast(NodeId, manager_node_id + 1)


### PR DESCRIPTION
This pull request introduces a utility function to streamline type casting for Mirage node IDs and updates related code to use this new function. It also removes an unused import from `core/checks/mirage.py`.

### Code enhancements for Mirage node ID handling:

* **New utility function**: Added `cast_manager_to_mirage_node_id` in `tools/helper.py` to simplify casting manager node IDs to `NodeId` objects.
* **Refactored usages**: Updated `get_base_port_from_mirage_manager` in `core/checks/mirage.py` and `generate_mirage_config_with_manager` in `core/config/mirage/generator.py` to use the new `cast_manager_to_mirage_node_id` function for type casting. [[1]](diffhunk://#diff-4e4da57fbad98223f9a788306d5c499c3ba49e9507e5fd1df8e16d8de19d3dc3R44-R52) [[2]](diffhunk://#diff-a1097d90cc648485aae88e7f9bfb6477dcc644e60d6239ba1e32db0be4ce16acL67-R68)

### Cleanup:

* **Unused import removal**: Removed the unused `NodeId` import from `core/checks/mirage.py`.