### PR TITLE
Add mirage wallet bp

### DIFF
--- a/mirage_api.py
+++ b/mirage_api.py
@@ -27,15 +27,14 @@ import werkzeug
 from flask import Flask, g
 
 from core.node_config import NodeConfig
-
 from tools.configs import FLASK_SECRET_KEY_FILE
 from tools.docker_utils import DockerUtils
 from tools.helper import wait_until_admin_inited
 from tools.logger import init_api_logger
-
-from web.routes.mirage_node import mirage_node_bp
 from web.helper import construct_err_response
 from web.routes.info import info_bp
+from web.routes.mirage_node import mirage_node_bp
+from web.routes.mirage_wallet import wallet_bp
 
 REQ_ID_SIZE = 10
 
@@ -46,6 +45,7 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 app.register_blueprint(mirage_node_bp)
 app.register_blueprint(info_bp)
+app.register_blueprint(wallet_bp)
 
 
 @app.before_request

--- a/web/routes/mirage_node.py
+++ b/web/routes/mirage_node.py
@@ -65,7 +65,11 @@ def register():
         return construct_err_response(
             msg=f'Error registering node: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
         )
+    node_config: NodeConfig = NodeConfig()
     node = mirage.nodes.get_by_address(mirage.wallet.address)
+    node_config.id = node.id
+    node_config.ip = ip
+    node_config.schain_base_port = port
     return construct_ok_response({'node': str(node)})
 
 

--- a/web/routes/mirage_wallet.py
+++ b/web/routes/mirage_wallet.py
@@ -1,0 +1,70 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE Admin
+#
+#   Copyright (C) 2019 SKALE Labs
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+
+from flask import Blueprint, g, request
+from skale.utils.account_tools import send_eth as send_eth_
+from skale.utils.web3_utils import to_checksum_address
+
+from web.helper import construct_err_response, construct_ok_response, g_mirage, get_api_url
+
+logger = logging.getLogger(__name__)
+BLUEPRINT_NAME = 'wallet'
+
+
+wallet_bp = Blueprint(BLUEPRINT_NAME, __name__)
+
+
+def wallet_with_balance(mirage):
+    address = mirage.wallet.address
+    mirage_balance_wei = mirage.web3.eth.get_balance(address)
+    return {
+        'address': to_checksum_address(address),
+        'mirage_balance_wei': mirage_balance_wei,
+        'mirage_balance': str(mirage.web3.from_wei(mirage_balance_wei, 'ether')),
+    }
+
+
+@wallet_bp.route(get_api_url(BLUEPRINT_NAME, 'info'), methods=['GET'])
+@g_mirage
+def info():
+    logger.debug(request)
+    res = wallet_with_balance(g.mirage)
+    return construct_ok_response(data=res)
+
+
+@wallet_bp.route(get_api_url(BLUEPRINT_NAME, 'send-eth'), methods=['POST'])
+@g_mirage
+def send_eth():
+    logger.debug(request)
+    raw_address = request.json.get('address')
+    eth_amount = request.json.get('amount')
+    if not raw_address:
+        return construct_err_response('Address is empty')
+    if not eth_amount:
+        return construct_err_response('Amount is empty')
+    try:
+        address = to_checksum_address(raw_address)
+        logger.info('Sending %s wei to %s', eth_amount, address)
+        send_eth_(g.mirage.web3, g.mirage.wallet, address, eth_amount)
+    except Exception:
+        logger.exception('Funds were not sent due to error')
+        return construct_err_response(msg='Funds sending failed')
+    return construct_ok_response()


### PR DESCRIPTION
This pull request introduces significant updates to the Mirage API, primarily focusing on the integration of wallet-related functionality and enhancements to the node registration process. The most important changes include the addition of a new `wallet_bp` blueprint, updates to the `mirage_api.py` file to register this blueprint, and modifications to the `register` function in `mirage_node.py` to include node configuration details.

### Wallet Functionality Integration:

* **Addition of `wallet_bp` Blueprint**: Created a new `wallet_bp` blueprint in `web/routes/mirage_wallet.py` to handle wallet-related operations, including fetching wallet information and sending ETH.
* **Registration of `wallet_bp` in `mirage_api.py`**: Updated `mirage_api.py` to import and register the `wallet_bp` blueprint, enabling wallet-related routes in the Flask application. [[1]](diffhunk://#diff-17c45bc87befe18ad87c48a02c55f26e8a7ef02c91b9af30f65de33105a38eabL30-R37) [[2]](diffhunk://#diff-17c45bc87befe18ad87c48a02c55f26e8a7ef02c91b9af30f65de33105a38eabR48)

### Node Registration Enhancements:

* **Updated `register` Function in `mirage_node.py`**: Enhanced the `register` function to initialize a `NodeConfig` object and populate it with node-specific details such as ID, IP, and base port.