### PR TITLE
Add fair startup support

### DIFF
--- a/core/checks/mirage.py
+++ b/core/checks/mirage.py
@@ -23,6 +23,7 @@ import os
 from typing import cast
 
 from skale.mirage_manager import MirageManager
+from skale.types.committee import CommitteeIndex
 
 from core.checks.base import BaseSkaledChecks, CheckRes, IChecks
 from core.config.endpoint import get_base_port_from_config
@@ -58,7 +59,7 @@ class MirageConfigChecks(IChecks):
         mirage: MirageManager,
         node_config: NodeConfig,
         chain_name: MirageChainName,
-        group_index: int,
+        committee_index: CommitteeIndex,
         stream_version: str,
         chain_record: ChainRecord,
     ) -> None:
@@ -66,7 +67,7 @@ class MirageConfigChecks(IChecks):
         self.node_config = node_config
         self.mirage = mirage
         self.chain_record = chain_record
-        self.group_index = group_index
+        self.committee_index = committee_index
         self.stream_version = stream_version
         self.cfm: ConfigFileManager = ConfigFileManager(chain_name=chain_name)
         self.statsd_client = get_statsd_client()
@@ -87,7 +88,7 @@ class MirageConfigChecks(IChecks):
     @property
     def dkg(self) -> CheckRes:
         """Checks that DKG procedure is completed"""
-        secret_key_share_filepath = get_secret_key_share_filepath(self.name, self.group_index)
+        secret_key_share_filepath = get_secret_key_share_filepath(self.name, self.committee_index)
         return CheckRes(os.path.isfile(secret_key_share_filepath))
 
     @property
@@ -98,14 +99,14 @@ class MirageConfigChecks(IChecks):
         and config regeneration was not triggered manually.
         Returns False otherwise.
         """
-        exists = self.cfm.upstream_exist_for_rotation_id(self.group_index)
+        exists = self.cfm.upstream_exist_for_rotation_id(self.committee_index)
         logger.debug('Upstream configs status for %s: %s', self.name, exists)
         stream_updated = self.chain_record.config_version == self.stream_version
         triggered = self.chain_record.sync_config_run
 
         logger.info(
-            'Upstream config status, group_index %s: exist: %s,stream: %s, triggered: %s',
-            self.group_index,
+            'Upstream config status, committee_index %s: exist: %s,stream: %s, triggered: %s',
+            self.committee_index,
             exists,
             stream_updated,
             triggered,

--- a/core/config/mirage/committee.py
+++ b/core/config/mirage/committee.py
@@ -34,8 +34,8 @@ class BlsKey:
     key_share_name: str
     t: int
     n: int
-    cert_file: str
-    key_file: str
+    cert_file: str | None
+    key_file: str | None
     common_bls_public_key: list[str]
     bls_public_key: list[str]
 
@@ -88,7 +88,7 @@ def generate_committee_bls_key(committee_index: int) -> BlsKey:
 
 def generate_committee_info(
     committee_info_from_manager: list[CommitteeGroup],
-    sync_node: bool = False,
+    is_committee_node: bool,
 ) -> Dict[int, CommitteeInfo]:
     committee_info = {}
     for committee in committee_info_from_manager:
@@ -96,7 +96,7 @@ def generate_committee_info(
         committee_group = committee['group']
         index = committee['index']
         bls_key = generate_committee_bls_key(index)
-        mirage_chain_nodes = generate_mirage_chain_nodes(committee_group, index, sync_node)
+        mirage_chain_nodes = generate_mirage_chain_nodes(committee_group, index, is_committee_node)
         committee_info[ts] = CommitteeInfo(bls_key=bls_key, group=mirage_chain_nodes)
 
     return committee_info

--- a/core/config/mirage/committee.py
+++ b/core/config/mirage/committee.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass
 from typing import Dict
 
 from skale.types.committee import CommitteeGroup
+from skale.types.node import NodeId
+from skale.types.dkg import G2Point
 
 from core.config.mirage.mirage_chain_node import MirageChainNodeInfo, generate_mirage_chain_nodes
 from core.config.schain.static_params import get_mirage_chain_name
@@ -31,21 +33,18 @@ from tools.helper import read_json
 
 @dataclass
 class BlsKey:
-    key_share_name: str
-    t: int
     n: int
-    cert_file: str | None
-    key_file: str | None
     common_bls_public_key: list[str]
     bls_public_key: list[str]
 
+    key_share_name: str | None
+    t: int | None
+    cert_file: str | None
+    key_file: str | None
+
     def to_dict(self):
-        result = {
-            'keyShareName': self.key_share_name,
-            't': self.t,
+        result: dict = {
             'n': self.n,
-            'certFile': self.cert_file,
-            'keyFile': self.key_file,
         }
 
         for i, key in enumerate(self.common_bls_public_key):
@@ -53,6 +52,15 @@ class BlsKey:
 
         for i, key in enumerate(self.bls_public_key):
             result[f'BLSPublicKey{i}'] = key
+
+        if self.key_share_name is not None:
+            result['keyShareName'] = self.key_share_name
+        if self.t is not None:
+            result['t'] = self.t
+        if self.cert_file is not None:
+            result['certFile'] = self.cert_file
+        if self.key_file is not None:
+            result['keyFile'] = self.key_file
 
         return result
 
@@ -69,7 +77,24 @@ class CommitteeInfo:
         }
 
 
-def generate_committee_bls_key(committee_index: int) -> BlsKey:
+def generate_committee_bls_key(
+    committee_index: int,
+    is_committee_node: bool,
+    n: int,
+    common_bls_public_key: list[str],
+) -> BlsKey:
+    # todod: handle the case for passive nodes
+    if not is_committee_node:
+        return BlsKey(
+            key_share_name='',  # todod
+            t=1,  # todod
+            n=n,
+            cert_file=SGX_SSL_CERT_FILEPATH,
+            key_file=SGX_SSL_KEY_FILEPATH,
+            common_bls_public_key=common_bls_public_key,
+            bls_public_key=['0', '0', '1', '0'],
+        )
+
     secret_key_share_filepath = get_secret_key_share_filepath(
         get_mirage_chain_name(), committee_index
     )
@@ -86,16 +111,31 @@ def generate_committee_bls_key(committee_index: int) -> BlsKey:
     )
 
 
+# todod: move from here
+def get_common_bls_public_key(common_bls_public_key: G2Point) -> list[str]:
+    return [elem for coord in common_bls_public_key for elem in coord]
+
+
 def generate_committee_info(
     committee_info_from_manager: list[CommitteeGroup],
-    is_committee_node: bool,
+    node_id: NodeId,
 ) -> Dict[int, CommitteeInfo]:
     committee_info = {}
     for committee in committee_info_from_manager:
         ts = committee['ts']
         committee_group = committee['group']
         index = committee['index']
-        bls_key = generate_committee_bls_key(index)
+
+        is_committee_node = any(node.id == node_id for node in committee_group)
+        common_bls_public_key = committee['committee'].common_public_key
+
+        bls_key = generate_committee_bls_key(
+            index,
+            is_committee_node,
+            len(committee_group),
+            get_common_bls_public_key(common_bls_public_key),
+        )
+
         mirage_chain_nodes = generate_mirage_chain_nodes(committee_group, index, is_committee_node)
         committee_info[ts] = CommitteeInfo(bls_key=bls_key, group=mirage_chain_nodes)
 

--- a/core/config/mirage/generator.py
+++ b/core/config/mirage/generator.py
@@ -29,6 +29,7 @@ from skale.types.committee import CommitteeGroup
 from skale.types.node import MirageNode, NodeId, NodeWithSchains
 from skale.types.node import Node as SkaleNode
 from skale.types.rotation import NodesGroup
+from skale.types.committee import CommitteeIndex, TimeStamp
 from skale.utils.web3_utils import public_key_to_address, to_checksum_address
 
 from core.config.base import MirageConfig, SChainBaseConfig
@@ -62,9 +63,8 @@ class MirageSkaleConfig:
 def generate_mirage_config_with_manager(
     mirage: MirageManager,
     node_id: NodeId,
-    group_index: int,
     ecdsa_key_name: str,
-    sync_node: bool,
+    is_committee_node: bool,
     archive: bool,
     catchup: bool,
 ) -> MirageConfig:
@@ -78,7 +78,7 @@ def generate_mirage_config_with_manager(
         committee_info_from_manager=committee_nodes_in_scope,
         node_groups=node_groups,
         ecdsa_key_name=ecdsa_key_name,
-        sync_node=sync_node,
+        is_committee_node=is_committee_node,
         archive=archive,
         catchup=catchup,
     )
@@ -115,15 +115,15 @@ def generate_mirage_config_adapter(
     ]
 
     committee_info_from_manager: list[CommitteeGroup] = [
-        {'ts': 0, 'index': 0, 'group': committee_nodes},
-        {'ts': chain_start_ts, 'index': 0, 'group': committee_nodes},
+        {'ts': TimeStamp(0), 'index': CommitteeIndex(0), 'group': committee_nodes},
+        {'ts': TimeStamp(chain_start_ts), 'index': CommitteeIndex(0), 'group': committee_nodes},
     ]
     return generate_mirage_config(
         node=node,
         committee_info_from_manager=committee_info_from_manager,
         node_groups=node_groups,
         ecdsa_key_name=ecdsa_key_name,
-        sync_node=sync_node,
+        is_committee_node=True,
         archive=archive,
         catchup=catchup,
     )
@@ -134,7 +134,7 @@ def generate_mirage_config(
     committee_info_from_manager: list[CommitteeGroup],
     node_groups: Dict[int, NodesGroup],
     ecdsa_key_name: str,
-    sync_node: bool = False,
+    is_committee_node: bool,
     archive: bool = False,
     catchup: bool = False,
 ) -> MirageConfig:
@@ -155,7 +155,7 @@ def generate_mirage_config(
 
     committee_info = generate_committee_info(
         committee_info_from_manager=committee_info_from_manager,
-        sync_node=sync_node,
+        is_committee_node=is_committee_node,
     )
 
     schain_info = MirageChainInfo(
@@ -172,7 +172,7 @@ def generate_mirage_config(
         ecdsa_key_name=ecdsa_key_name,
         static_node_info=static_node_info,
         port=node.port,
-        sync_node=sync_node,
+        is_committee_node=is_committee_node,
         archive=archive,
         catchup=catchup,
     )

--- a/core/config/mirage/generator.py
+++ b/core/config/mirage/generator.py
@@ -75,21 +75,6 @@ def generate_mirage_config_with_manager(
     committee_nodes_in_scope = get_nodes_from_last_two_committees(mirage)
     node_groups = generate_committee_history(mirage=mirage)
 
-    # todod: fix for indexes!
-    # node_groups['0']['nodes'][3] = (
-    #     0,
-    #     3,
-    #     '0x5955e93caeab3fe22b1ab79f4eed4ebcadda9a65410dced97388b4e99c1f718fa915295c620d81ed875ff164253a2c5e0672ae2946d66f323ef4f6a03b3e8fdf',
-    # )
-    # node_groups['0']['nodes'][2] = (
-    #     1,
-    #     2,
-    #     '0xd80a0c19d3daf562faee0aaed89c19d0f28178db423f3dd6af386b9a95827a688b6bc2df60d69be8d644fb2675881b76c8068cd105fd0c50eaa42eb772b60b20',
-    # )
-
-    # committee_nodes_in_scope[0]['group'].reverse()
-    # committee_nodes_in_scope[1]['group'].reverse()
-
     return generate_mirage_config(
         node=node,
         committee_info_from_manager=committee_nodes_in_scope,

--- a/core/config/mirage/generator.py
+++ b/core/config/mirage/generator.py
@@ -29,7 +29,9 @@ from skale.types.committee import CommitteeGroup
 from skale.types.node import MirageNode, NodeId, NodeWithSchains
 from skale.types.node import Node as SkaleNode
 from skale.types.rotation import NodesGroup
-from skale.types.committee import CommitteeIndex, TimeStamp
+from skale.types.committee import CommitteeIndex, TimeStamp, Committee
+from skale.types.dkg import G2Point, DkgId, Fp2Point
+
 from skale.utils.web3_utils import public_key_to_address, to_checksum_address
 
 from core.config.base import MirageConfig, SChainBaseConfig
@@ -73,6 +75,21 @@ def generate_mirage_config_with_manager(
     committee_nodes_in_scope = get_nodes_from_last_two_committees(mirage)
     node_groups = generate_committee_history(mirage=mirage)
 
+    # todod: fix for indexes!
+    # node_groups['0']['nodes'][3] = (
+    #     0,
+    #     3,
+    #     '0x5955e93caeab3fe22b1ab79f4eed4ebcadda9a65410dced97388b4e99c1f718fa915295c620d81ed875ff164253a2c5e0672ae2946d66f323ef4f6a03b3e8fdf',
+    # )
+    # node_groups['0']['nodes'][2] = (
+    #     1,
+    #     2,
+    #     '0xd80a0c19d3daf562faee0aaed89c19d0f28178db423f3dd6af386b9a95827a688b6bc2df60d69be8d644fb2675881b76c8068cd105fd0c50eaa42eb772b60b20',
+    # )
+
+    # committee_nodes_in_scope[0]['group'].reverse()
+    # committee_nodes_in_scope[1]['group'].reverse()
+
     return generate_mirage_config(
         node=node,
         committee_info_from_manager=committee_nodes_in_scope,
@@ -115,8 +132,28 @@ def generate_mirage_config_adapter(
     ]
 
     committee_info_from_manager: list[CommitteeGroup] = [
-        {'ts': TimeStamp(0), 'index': CommitteeIndex(0), 'group': committee_nodes},
-        {'ts': TimeStamp(chain_start_ts), 'index': CommitteeIndex(0), 'group': committee_nodes},
+        {
+            'ts': TimeStamp(0),
+            'index': CommitteeIndex(0),
+            'group': committee_nodes,
+            'committee': Committee(
+                node_ids=[node.id for node in committee_nodes],
+                dkg_id=DkgId(0),
+                common_public_key=G2Point(Fp2Point(a=1, b=2), Fp2Point(a=3, b=4)),
+                starting_timestamp=TimeStamp(0),
+            ),
+        },
+        {
+            'ts': TimeStamp(chain_start_ts),
+            'index': CommitteeIndex(0),
+            'group': committee_nodes,
+            'committee': Committee(
+                node_ids=[node.id for node in committee_nodes],
+                dkg_id=DkgId(0),
+                common_public_key=G2Point(Fp2Point(a=1, b=2), Fp2Point(a=3, b=4)),
+                starting_timestamp=TimeStamp(0),
+            ),
+        },
     ]
     return generate_mirage_config(
         node=node,

--- a/core/config/mirage/generator.py
+++ b/core/config/mirage/generator.py
@@ -155,7 +155,7 @@ def generate_mirage_config(
 
     committee_info = generate_committee_info(
         committee_info_from_manager=committee_info_from_manager,
-        is_committee_node=is_committee_node,
+        node_id=node.id,
     )
 
     schain_info = MirageChainInfo(

--- a/core/config/mirage/helper.py
+++ b/core/config/mirage/helper.py
@@ -1,5 +1,25 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE Admin
+#
+#   Copyright (C) 2025 SKALE Labs
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import time
 from typing import Dict, List
+from skale.types.node import NodeId
 
 
 def get_current_nodes(config: Dict) -> List[dict]:
@@ -19,6 +39,15 @@ def get_current_nodes(config: Dict) -> List[dict]:
     if needed_timestamp is None:
         needed_timestamp = max(timestamps)
     return schain_nodes_config[needed_timestamp]['group']
+
+
+def is_node_in_current_config_group(config: Dict | None, node_id: NodeId) -> bool:
+    if config is None:
+        return False
+    group_data = get_current_nodes(config)
+    if len(group_data) == 0:
+        return False
+    return any(node_data['nodeID'] == node_id for node_data in group_data)
 
 
 def get_node_ips_from_config(config: Dict) -> List[str]:

--- a/core/config/mirage/mirage_chain_node.py
+++ b/core/config/mirage/mirage_chain_node.py
@@ -50,14 +50,14 @@ class MirageChainNodeInfo(NodeInfo):
 
 
 def generate_mirage_chain_nodes(
-    committee_nodes: list[MirageNode], committee_id: int, sync_node: bool = False
+    committee_nodes: list[MirageNode], committee_id: int, is_committee_node: bool
 ) -> list[MirageChainNodeInfo]:
     chain_nodes = []
 
-    if sync_node:
-        bls_public_keys = ['0:0:1:0'] * len(committee_nodes)
-    else:
+    if is_committee_node:
         bls_public_keys = get_bls_public_keys(get_mirage_chain_name(), committee_id)
+    else:
+        bls_public_keys = ['0:0:1:0'] * len(committee_nodes)
 
     for i, node in enumerate(committee_nodes, 1):
         node_info = MirageChainNodeInfo(

--- a/core/config/mirage/node_info.py
+++ b/core/config/mirage/node_info.py
@@ -47,9 +47,10 @@ class MirageCurrentNodeInfo(NodeInfo):
                 **self.static_node_info,
             },
         }
-        if not self.is_committee_node:
-            node_info['archiveMode'] = self.archive
-            node_info['syncFromCatchup'] = self.catchup
+        # todod: handle later
+        # if not self.is_committee_node:
+        #     node_info['archiveMode'] = self.archive
+        #     node_info['syncFromCatchup'] = self.catchup
         return node_info
 
 

--- a/core/config/mirage/node_info.py
+++ b/core/config/mirage/node_info.py
@@ -32,7 +32,7 @@ class MirageCurrentNodeInfo(NodeInfo):
 
     ecdsa_key_name: str
     static_node_info: dict
-    sync_node: bool
+    is_committee_node: bool
     catchup: bool
     archive: bool
 
@@ -42,12 +42,12 @@ class MirageCurrentNodeInfo(NodeInfo):
             **super().to_dict(),
             **{
                 'ecdsaKeyName': self.ecdsa_key_name,
-                'syncNode': self.sync_node,
+                'syncNode': not self.is_committee_node,
                 'info-acceptors': 1,
                 **self.static_node_info,
             },
         }
-        if self.sync_node:
+        if not self.is_committee_node:
             node_info['archiveMode'] = self.archive
             node_info['syncFromCatchup'] = self.catchup
         return node_info
@@ -58,7 +58,7 @@ def generate_mirage_current_node_info(
     ecdsa_key_name: str,
     static_node_info: dict,
     port: Port,
-    sync_node: bool = False,
+    is_committee_node: bool,
     archive: bool = False,
     catchup: bool = False,
 ) -> MirageCurrentNodeInfo:
@@ -70,7 +70,7 @@ def generate_mirage_current_node_info(
         name=str(node_id),
         base_port=port,
         ecdsa_key_name=ecdsa_key_name,
-        sync_node=sync_node,
+        is_committee_node=is_committee_node,
         archive=archive,
         catchup=catchup,
         static_node_info=static_node_info,

--- a/core/firewall/__init__.py
+++ b/core/firewall/__init__.py
@@ -23,13 +23,13 @@ from .schain.rule_controller import SChainRuleController  # noqa
 from .mirage.rule_controller import (
     MirageController,  # noqa
     MirageCommitteeScopeRuleController,  # noqa
-    MirageNetworkScopeRuleController, # noqa
+    MirageNetworkScopeRuleController,  # noqa
 )  # noqa
 from .base.types import (
     Action,  # noqa
     IpRange,  # noqa
     IRuleController,  # noqa
-    LOOPBACK_INTERFACE, # noqa
+    LOOPBACK_INTERFACE,  # noqa
     SChainRule,  # noqa
     SkaledPorts,  # noqa
 )  # noqa

--- a/core/firewall/mirage/firewall_manager.py
+++ b/core/firewall/mirage/firewall_manager.py
@@ -20,6 +20,7 @@
 from ..base.firewall_manager import NFTChainFirewallManager
 from ..base.nftables import NFTablesController
 
+
 class NFTMirageChainFirewallManager(NFTChainFirewallManager):
     def create_host_controller(self) -> NFTablesController:
         nc_controller = NFTablesController(chain=self.group, prefix='mirage')

--- a/core/firewall/mirage/rule_controller.py
+++ b/core/firewall/mirage/rule_controller.py
@@ -197,10 +197,10 @@ class MirageNetworkScopeRuleController(MirageController):
 
     @configured_only
     def expected_rules(self) -> Iterable[SChainRule]:
-
         return sorted(
             itertools.chain.from_iterable(
-                (self.public_rules, self.network_scope_rules , self.drop_rules))
+                (self.public_rules, self.network_scope_rules, self.drop_rules)
+            )
         )
 
 
@@ -237,5 +237,5 @@ class MirageCommitteeScopeRuleController(MirageController):
     @configured_only
     def expected_rules(self) -> Iterable[SChainRule]:
         return sorted(
-            itertools.chain.from_iterable(
-                (self.committee_scope_rules, [], self.drop_rules)))
+            itertools.chain.from_iterable((self.committee_scope_rules, [], self.drop_rules))
+        )

--- a/core/firewall/schain/firewall_manager.py
+++ b/core/firewall/schain/firewall_manager.py
@@ -20,6 +20,7 @@
 from ..base.firewall_manager import NFTChainFirewallManager
 from ..base.nftables import NFTablesController
 
+
 class NFTSkaleChainFirewallManager(NFTChainFirewallManager):
     def create_host_controller(self) -> NFTablesController:
         nc_controller = NFTablesController(chain=self.group, prefix='skale')

--- a/core/firewall/schain/rule_controller.py
+++ b/core/firewall/schain/rule_controller.py
@@ -76,7 +76,7 @@ class SChainRuleController(IRuleController):
         self.sync_ip_ranges = sync_ip_ranges or []
         self.port_allocation = port_allocation
         self.ports_per_schain = ports_per_schain
-        self._firewall_manager: IFirewallManager | None  =  None
+        self._firewall_manager: IFirewallManager | None = None
 
     def get_missing(self) -> Dict['str', Any]:
         missing: Dict['str', Any] = {}
@@ -222,7 +222,6 @@ class NFTSchainRuleController(SChainRuleController):
             self.base_port,  # type: ignore
             self.base_port + self.ports_per_schain - 1,  # type: ignore
         )
-
 
     @property
     def firewall_manager(self) -> NFTSkaleChainFirewallManager:

--- a/core/monitor/mirage/action_config.py
+++ b/core/monitor/mirage/action_config.py
@@ -20,6 +20,7 @@
 import logging
 
 from skale import MirageManager
+from skale.types.committee import CommitteeIndex
 
 from core.checks.mirage import MirageConfigChecks
 from core.config.mirage.generator import generate_mirage_config_with_manager
@@ -33,7 +34,6 @@ from core.redis.chain_record import ChainRecord
 from core.redis.node_config_mirage import NodeConfigMirage
 from core.types.chain import MirageChainName
 from core.utils.mirage import get_local_skaled_endpoint_mirage
-from tools.configs import SYNC_NODE
 from tools.helper import no_hyphens
 from tools.node_options import NodeOptions
 from tools.resources import get_statsd_client
@@ -46,7 +46,7 @@ class MirageConfigActionManager(BaseActionManager):
         self,
         mirage: MirageManager,
         chain_name: MirageChainName,
-        group_index: int,
+        committee_index: CommitteeIndex,
         node_config: NodeConfig,
         stream_version: str,
         checks: MirageConfigChecks,
@@ -57,7 +57,7 @@ class MirageConfigActionManager(BaseActionManager):
         self.checks = checks
         self.stream_version = stream_version
         self.chain_name = chain_name
-        self.group_index = group_index
+        self.committee_index = committee_index
         self.rule_controller = get_mirage_network_scope_rule_controller()
 
         self.node_options = node_options or NodeOptions()
@@ -115,20 +115,20 @@ class MirageConfigActionManager(BaseActionManager):
         return initial_status
 
     @BaseActionManager.monitor_block
-    def upstream_config(self) -> bool:
+    def upstream_config(self, is_committee_node: bool) -> bool:
         with self.statsd_client.timer(f'admin.action.upstream_config.{no_hyphens(self.name)}'):
             logger.info(
-                'Generating new upstream_config group_index: %s, stream: %s',
-                self.group_index,
+                'Generating new upstream_config committee_index: %s, stream: %s, is_committee_node: %s',
+                self.committee_index,
                 self.stream_version,
+                is_committee_node,
             )
 
             new_config = generate_mirage_config_with_manager(
                 mirage=self.mirage,
                 node_id=self.node_config.id,
-                group_index=self.group_index,
                 ecdsa_key_name=self.node_config.sgx_key_name,
-                sync_node=SYNC_NODE,
+                is_committee_node=is_committee_node,
                 archive=self.node_options.archive,
                 catchup=self.node_options.catchup,
             ).to_dict()
@@ -139,8 +139,8 @@ class MirageConfigActionManager(BaseActionManager):
                 or new_config != self.cfm.latest_upstream_config
             ):
                 logger.info('Saving new config')
-                logger.info('Saving new upstream config group_index: %d', self.group_index)
-                self.cfm.save_new_upstream(self.group_index, new_config)
+                logger.info('Saving new upstream config committee_index: %d', self.committee_index)
+                self.cfm.save_new_upstream(self.committee_index, new_config)
                 result = True
             else:
                 logger.info('Generated config is the same as latest upstream')

--- a/core/monitor/mirage/action_config.py
+++ b/core/monitor/mirage/action_config.py
@@ -118,7 +118,8 @@ class MirageConfigActionManager(BaseActionManager):
     def upstream_config(self, is_committee_node: bool) -> bool:
         with self.statsd_client.timer(f'admin.action.upstream_config.{no_hyphens(self.name)}'):
             logger.info(
-                'Generating new upstream_config committee_index: %s, stream: %s, is_committee_node: %s',
+                'Generating new upstream_config committee_index: \
+%s, stream: %s, is_committee_node: %s',
                 self.committee_index,
                 self.stream_version,
                 is_committee_node,

--- a/core/monitor/mirage/action_skaled.py
+++ b/core/monitor/mirage/action_skaled.py
@@ -39,7 +39,6 @@ from core.monitor.action_base import (
 from core.node_config import NodeConfig
 from core.schains.cleaner import remove_skaled_container
 from core.types.chain import MirageChainName
-from tools.configs import SYNC_NODE
 from tools.configs.containers import SKALED_CONTAINER
 from tools.docker_utils import DockerUtils
 from tools.node_options import NodeOptions

--- a/core/monitor/mirage/action_skaled.py
+++ b/core/monitor/mirage/action_skaled.py
@@ -88,7 +88,8 @@ class MirageSkaledActionManager(BaseSkaledActionManager):
             start_ts=start_ts,
             abort_on_exit=abort_on_exit,
             dutils=self.dutils,
-            sync_node=SYNC_NODE,
+            # sync_node=SYNC_NODE,
+            sync_node=True,  # todod: tmp, handle it later - skaled should be fixed
             historic_state=self.node_options.historic_state,
         )
         time.sleep(CONTAINER_POST_RUN_DELAY)

--- a/core/monitor/mirage/action_skaled.py
+++ b/core/monitor/mirage/action_skaled.py
@@ -30,6 +30,7 @@ from core.config.mirage.firewall import (
     get_node_ips_from_config,
     get_own_ip_from_config,
 )
+from core.config.mirage.helper import is_node_in_current_config_group
 from core.firewall import MirageCommitteeScopeRuleController
 from core.monitor.action_base import (
     CONTAINER_POST_RUN_DELAY,
@@ -78,6 +79,12 @@ class MirageSkaledActionManager(BaseSkaledActionManager):
             download_snapshot,
             start_ts,
         )
+
+        node_in_current_config = is_node_in_current_config_group(
+            self.cfm.skaled_config, self.node_config.id
+        )
+        sync_node = not node_in_current_config  # todod: tmp, handle it later
+
         monitor_skaled_container(
             self.chain_name,
             chain_record=self.chain_record,
@@ -87,8 +94,7 @@ class MirageSkaledActionManager(BaseSkaledActionManager):
             start_ts=start_ts,
             abort_on_exit=abort_on_exit,
             dutils=self.dutils,
-            # sync_node=SYNC_NODE,
-            sync_node=True,  # todod: tmp, handle it later - skaled should be fixed
+            sync_node=sync_node,  # todod: tmp, handle it later - skaled should be fixed
             historic_state=self.node_options.historic_state,
         )
         time.sleep(CONTAINER_POST_RUN_DELAY)

--- a/core/monitor/mirage/monitor_config.py
+++ b/core/monitor/mirage/monitor_config.py
@@ -24,13 +24,13 @@ from abc import abstractmethod
 from skale import MirageManager
 
 from core.checks.mirage import MirageConfigChecks
+from core.config.mirage import committee
 from core.monitor.mirage.action_config import MirageConfigActionManager
 from core.monitor.monitor_base import IMonitor
 from core.node_config import NodeConfig
 from core.redis.chain_record import ChainRecord
 from core.types.chain import MirageChainName
 
-from tools.configs import SYNC_NODE
 from tools.helper import no_hyphens
 from tools.resources import get_statsd_client
 
@@ -45,8 +45,14 @@ def run_config_pipeline(
 ) -> None:
     logger.info('Running config pipeline for %s', chain_name)
 
-    # todod: get current group index from mirage
-    group_index = 0
+    committee_index = mirage.committee.get_active_committee_index()
+    is_committee_node = mirage.committee.is_node_in_current_or_next_committee(node_config.id)
+
+    logger.info(
+        'Running config pipeline, committee index: %s, is committee node: %s',
+        committee_index,
+        is_committee_node,
+    )
 
     chain_record = ChainRecord(chain_name)
     logger.info('Chain record: %s', chain_record)
@@ -57,7 +63,7 @@ def run_config_pipeline(
         node_config=node_config,
         chain_name=chain_name,
         stream_version=stream_version,
-        group_index=group_index,
+        committee_index=committee_index,
         chain_record=chain_record,
     )
 
@@ -65,7 +71,7 @@ def run_config_pipeline(
     config_am = MirageConfigActionManager(
         mirage=mirage,
         chain_name=chain_name,
-        group_index=group_index,
+        committee_index=committee_index,
         node_config=node_config,
         stream_version=stream_version,
         checks=config_checks,
@@ -75,18 +81,18 @@ def run_config_pipeline(
     status = config_checks.get_all(log=False, expose=True)
     logger.info('Config status: %s', status)
 
-    if SYNC_NODE:
+    if is_committee_node:
         logger.info('Sync node mode, running sync config monitor')
-        mon = SyncConfigMonitor(config_am, config_checks)
+        mon = ActiveConfigMonitor(config_am, config_checks)
     else:
-        logger.info('Regular node mode, running config monitor')
-        mon = RegularConfigMonitor(config_am, config_checks)
+        logger.info('Committee node mode, running config monitor')
+        mon = CommitteeConfigMonitor(config_am, config_checks)
     statsd_client = get_statsd_client()
 
     statsd_client.incr(f'admin.config_pipeline.{mon.__class__.__name__}.{no_hyphens(chain_name)}')
     statsd_client.gauge(
         f'admin.config_pipeline.rotation_id.{no_hyphens(chain_name)}',
-        group_index,
+        committee_index,
     )
     with statsd_client.timer(f'admin.config_pipeline.duration.{no_hyphens(chain_name)}'):
         mon.run()
@@ -117,23 +123,25 @@ class BaseConfigMonitor(IMonitor):
             logger.info('Config monitor type finished %s', typename)
 
 
-class RegularConfigMonitor(BaseConfigMonitor):
+class CommitteeConfigMonitor(BaseConfigMonitor):
     def execute(self) -> None:
         if not self.checks.config_dir:
             self.am.config_dir()
         if not self.checks.dkg:
             self.am.dkg()
         if not self.checks.upstream_config:
-            self.am.upstream_config()
+            self.am.upstream_config(is_committee_node=True)
         if not self.checks.network_scope_firewall_rules:
             self.am.network_scope_firewall_rules()
         self.am.reset_config_record()
 
 
-class SyncConfigMonitor(BaseConfigMonitor):
+class ActiveConfigMonitor(BaseConfigMonitor):
     def execute(self) -> None:
         if not self.checks.config_dir:
             self.am.config_dir()
         if not self.checks.upstream_config:
-            self.am.upstream_config()
+            self.am.upstream_config(is_committee_node=False)
+        if not self.checks.network_scope_firewall_rules:
+            self.am.network_scope_firewall_rules()
         self.am.reset_config_record()

--- a/core/monitor/mirage/monitor_config.py
+++ b/core/monitor/mirage/monitor_config.py
@@ -82,11 +82,11 @@ def run_config_pipeline(
     logger.info('Config status: %s', status)
 
     if is_committee_node:
-        logger.info('Sync node mode, running sync config monitor')
-        mon = ActiveConfigMonitor(config_am, config_checks)
-    else:
         logger.info('Committee node mode, running config monitor')
         mon = CommitteeConfigMonitor(config_am, config_checks)
+    else:
+        logger.info('Active node mode, running sync config monitor')
+        mon = ActiveConfigMonitor(config_am, config_checks)
     statsd_client = get_statsd_client()
 
     statsd_client.incr(f'admin.config_pipeline.{mon.__class__.__name__}.{no_hyphens(chain_name)}')

--- a/core/monitor/mirage/monitor_config.py
+++ b/core/monitor/mirage/monitor_config.py
@@ -24,7 +24,6 @@ from abc import abstractmethod
 from skale import MirageManager
 
 from core.checks.mirage import MirageConfigChecks
-from core.config.mirage import committee
 from core.monitor.mirage.action_config import MirageConfigActionManager
 from core.monitor.monitor_base import IMonitor
 from core.node_config import NodeConfig

--- a/core/monitor/mirage/monitor_skaled.py
+++ b/core/monitor/mirage/monitor_skaled.py
@@ -20,6 +20,7 @@
 import logging
 from typing import Type
 
+from core.config.mirage.firewall import get_own_ip_from_config
 from core.firewall.utils import get_mirage_committee_scope_rule_controller
 from core.monitor.monitor_base import BaseSkaledMonitor
 from core.node_config import NodeConfig
@@ -127,23 +128,81 @@ class RegularSkaledMonitor(BaseSkaledMonitor):
             self._am.skaled_rpc()
 
 
+class NoConfigSkaledMonitor(BaseSkaledMonitor):
+    # todod: optimize this part: move init and am to the base class
+    def __init__(self, action_manager: MirageSkaledActionManager) -> None:
+        self._am: MirageSkaledActionManager = action_manager
+        self._checks = action_manager.checks
+
+    @property
+    def am(self) -> MirageSkaledActionManager:
+        return self._am
+
+    @property
+    def checks(self) -> SkaledChecks:
+        return self._checks
+
+    def execute(self):
+        if self.checks.upstream_exists:
+            logger.info('Creating skaled config')
+            self.am.update_config()
+        else:
+            logger.debug('Waiting for upstream config')
+
+
+class ActiveSkaledMonitor(BaseSkaledMonitor):
+    def __init__(self, action_manager: MirageSkaledActionManager) -> None:
+        self._am: MirageSkaledActionManager = action_manager
+        self._checks = action_manager.checks
+
+    @property
+    def am(self) -> MirageSkaledActionManager:
+        return self._am
+
+    @property
+    def checks(self) -> SkaledChecks:
+        return self._checks
+
+    def execute(self) -> None:
+        if not self.checks.volume:
+            self._am.volume()
+        if not self.checks.skaled_container:
+            # TODOD: handle download snapshot logic better
+            self._am.skaled_container(download_snapshot=True)
+        else:
+            self._am.reset_restart_counter()
+        if not self.checks.rpc:
+            self._am.skaled_rpc()
+
+
 def get_skaled_monitor(
     action_manager: MirageSkaledActionManager,
     check_status: dict,
     chain_record: ChainRecord,
     skaled_status: SkaledStatus | None,
-) -> Type[RegularSkaledMonitor]:
+) -> Type[BaseSkaledMonitor]:
     logger.info('Choosing skaled monitor')
     if skaled_status:
         skaled_status.log()
 
     mon_type: Type[BaseSkaledMonitor] = RegularSkaledMonitor
 
-    if SYNC_NODE:
-        # todod: implement sync node monitors
-        return mon_type
+    # todod: check if the node of a part of the CURRENT committee
+    # optimize this logic
+    config = action_manager.cfm.skaled_config
+    own_ip = get_own_ip_from_config(config)
+    in_current_committee = own_ip is not None
 
-    # todod: implement regualr node monitors
+    if not check_status['config']:
+        mon_type = NoConfigSkaledMonitor
+    elif not in_current_committee:
+        mon_type = ActiveSkaledMonitor
+
+    # if SYNC_NODE:
+    #     # todod: implement sync node monitors
+    #     return mon_type
+
+    # todod: implement regular node monitors
 
     # if not check_status['config']:
     #     mon_type = NoConfigSkaledMonitor

--- a/core/monitor/mirage/monitor_skaled.py
+++ b/core/monitor/mirage/monitor_skaled.py
@@ -167,8 +167,9 @@ class ActiveSkaledMonitor(BaseSkaledMonitor):
         if not self.checks.volume:
             self._am.volume()
         if not self.checks.skaled_container:
-            # TODOD: handle download snapshot logic better
-            self._am.skaled_container(download_snapshot=True)
+            # TODOD: handle download snapshot - skaled should be fixed
+            # self._am.skaled_container(download_snapshot=True)
+            self._am.skaled_container(download_snapshot=False)
         else:
             self._am.reset_restart_counter()
         if not self.checks.rpc:

--- a/core/monitor/schain/monitor_skaled.py
+++ b/core/monitor/schain/monitor_skaled.py
@@ -216,7 +216,7 @@ class NoConfigSkaledMonitor(BaseSChainSkaledMonitor):
 class NewNodeSkaledMonitor(BaseSChainSkaledMonitor):
     """
     When finish_ts is in the future and there is only one secret key share -
-    download snapshot and shedule start after finish_ts
+    download snapshot and schedule start after finish_ts
     """
 
     def execute(self):

--- a/mirage_api.py
+++ b/mirage_api.py
@@ -27,15 +27,14 @@ import werkzeug
 from flask import Flask, g
 
 from core.node_config import NodeConfig
-
 from tools.configs import FLASK_SECRET_KEY_FILE
 from tools.docker_utils import DockerUtils
 from tools.helper import wait_until_admin_inited
 from tools.logger import init_api_logger
-
-from web.routes.mirage_node import mirage_node_bp
 from web.helper import construct_err_response
 from web.routes.info import info_bp
+from web.routes.mirage_node import mirage_node_bp
+from web.routes.mirage_wallet import wallet_bp
 
 REQ_ID_SIZE = 10
 
@@ -46,6 +45,7 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 app.register_blueprint(mirage_node_bp)
 app.register_blueprint(info_bp)
+app.register_blueprint(wallet_bp)
 
 
 @app.before_request

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Jinja2==3.1.2
 
 docker==6.1.3
 
-skale.py==7.1dev4
+skale.py==7.1dev6
 
 requests==2.31
 ima-predeployed==2.1.0b0

--- a/tests/mirage/config_test.py
+++ b/tests/mirage/config_test.py
@@ -210,7 +210,7 @@ def test_generate_mirage_config_minimal_regular(
         committee_info_from_manager=committee_info_from_mirage_manager,
         node_groups=node_groups,
         ecdsa_key_name='NEK:SIMPLE_REGULAR',
-        sync_node=False,
+        is_committee_node=True,
         archive=False,
         catchup=False,
     )
@@ -248,7 +248,7 @@ def test_generate_mirage_config_minimal_sync(
         committee_info_from_manager=committee_info_from_mirage_manager,
         node_groups=node_groups,
         ecdsa_key_name='NEK:SIMPLE_REGULAR',
-        sync_node=True,
+        is_committee_node=False,
         archive=False,
         catchup=False,
     )
@@ -299,7 +299,7 @@ def test_generate_mirage_config_for_different_env_types(
                 committee_info_from_manager=committee_info_from_mirage_manager,
                 node_groups=node_groups,
                 ecdsa_key_name='NEK:SIMPLE_REGULAR',
-                sync_node=False,
+                is_committee_node=True,
                 archive=False,
                 catchup=False,
             )

--- a/tests/mirage/config_test.py
+++ b/tests/mirage/config_test.py
@@ -11,6 +11,8 @@ from skale.contracts.manager.schains import SchainStructure
 from skale.types.node import MirageNode, Node, NodeId, NodeStatus, NodeWithSchains, Port
 from skale.types.rotation import NodesGroup, NodesSwap, Rotation, RotationNodeData
 from skale.types.validator import ValidatorId
+from skale.types.committee import TimeStamp, Committee
+from skale.types.dkg import G2Point, DkgId, Fp2Point
 
 from core.config.base import MirageConfig
 from core.config.mirage.generator import generate_mirage_config, generate_mirage_config_adapter
@@ -33,8 +35,28 @@ MIRAGE_TEST_SECRET_KEY = {
 @pytest.fixture
 def committee_info_from_mirage_manager(mirage_node):
     committee_info_from_manager = [
-        {'ts': 0, 'index': 0, 'group': [mirage_node, mirage_node]},
-        {'ts': CURRENT_TS, 'index': 0, 'group': [mirage_node, mirage_node]},
+        {
+            'ts': 0,
+            'index': 0,
+            'group': [mirage_node, mirage_node],
+            'committee': Committee(
+                node_ids=[mirage_node.id, mirage_node.id],
+                dkg_id=DkgId(0),
+                common_public_key=G2Point(Fp2Point(a=1, b=2), Fp2Point(a=3, b=4)),
+                starting_timestamp=TimeStamp(0),
+            ),
+        },
+        {
+            'ts': CURRENT_TS,
+            'index': 0,
+            'group': [mirage_node, mirage_node],
+            'committee': Committee(
+                node_ids=[mirage_node.id, mirage_node.id],
+                dkg_id=DkgId(0),
+                common_public_key=G2Point(Fp2Point(a=1, b=2), Fp2Point(a=3, b=4)),
+                starting_timestamp=TimeStamp(0),
+            ),
+        },
     ]
     return committee_info_from_manager
 

--- a/web/routes/mirage_node.py
+++ b/web/routes/mirage_node.py
@@ -65,7 +65,11 @@ def register():
         return construct_err_response(
             msg=f'Error registering node: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
         )
+    node_config: NodeConfig = NodeConfig()
     node = mirage.nodes.get_by_address(mirage.wallet.address)
+    node_config.id = node.id
+    node_config.ip = ip
+    node_config.schain_base_port = port
     return construct_ok_response({'node': str(node)})
 
 

--- a/web/routes/mirage_wallet.py
+++ b/web/routes/mirage_wallet.py
@@ -1,0 +1,70 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE Admin
+#
+#   Copyright (C) 2019 SKALE Labs
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+
+from flask import Blueprint, g, request
+from skale.utils.account_tools import send_eth as send_eth_
+from skale.utils.web3_utils import to_checksum_address
+
+from web.helper import construct_err_response, construct_ok_response, g_mirage, get_api_url
+
+logger = logging.getLogger(__name__)
+BLUEPRINT_NAME = 'wallet'
+
+
+wallet_bp = Blueprint(BLUEPRINT_NAME, __name__)
+
+
+def wallet_with_balance(mirage):
+    address = mirage.wallet.address
+    mirage_balance_wei = mirage.web3.eth.get_balance(address)
+    return {
+        'address': to_checksum_address(address),
+        'mirage_balance_wei': mirage_balance_wei,
+        'mirage_balance': str(mirage.web3.from_wei(mirage_balance_wei, 'ether')),
+    }
+
+
+@wallet_bp.route(get_api_url(BLUEPRINT_NAME, 'info'), methods=['GET'])
+@g_mirage
+def info():
+    logger.debug(request)
+    res = wallet_with_balance(g.mirage)
+    return construct_ok_response(data=res)
+
+
+@wallet_bp.route(get_api_url(BLUEPRINT_NAME, 'send-eth'), methods=['POST'])
+@g_mirage
+def send_eth():
+    logger.debug(request)
+    raw_address = request.json.get('address')
+    eth_amount = request.json.get('amount')
+    if not raw_address:
+        return construct_err_response('Address is empty')
+    if not eth_amount:
+        return construct_err_response('Amount is empty')
+    try:
+        address = to_checksum_address(raw_address)
+        logger.info('Sending %s wei to %s', eth_amount, address)
+        send_eth_(g.mirage.web3, g.mirage.wallet, address, eth_amount)
+    except Exception:
+        logger.exception('Funds were not sent due to error')
+        return construct_err_response(msg='Funds sending failed')
+    return construct_ok_response()


### PR DESCRIPTION
This pull request introduces significant changes to the Mirage configuration and monitoring logic, focusing on replacing the `group_index` parameter with `committee_index` and introducing the concept of `is_committee_node`. These changes aim to improve clarity and functionality in handling committee-based configurations.

### Migration from `group_index` to `committee_index`:

* [`core/checks/mirage.py`](diffhunk://#diff-4e4da57fbad98223f9a788306d5c499c3ba49e9507e5fd1df8e16d8de19d3dc3R26): Replaced `group_index` with `committee_index` across the class properties and methods, such as in `__init__`, `config_dir`, and `upstream_config`. This ensures consistent naming and usage of committee-related indices. [[1]](diffhunk://#diff-4e4da57fbad98223f9a788306d5c499c3ba49e9507e5fd1df8e16d8de19d3dc3R26) [[2]](diffhunk://#diff-4e4da57fbad98223f9a788306d5c499c3ba49e9507e5fd1df8e16d8de19d3dc3L61-R70) [[3]](diffhunk://#diff-4e4da57fbad98223f9a788306d5c499c3ba49e9507e5fd1df8e16d8de19d3dc3L90-R91) [[4]](diffhunk://#diff-4e4da57fbad98223f9a788306d5c499c3ba49e9507e5fd1df8e16d8de19d3dc3L101-R109)

* [`core/monitor/mirage/action_config.py`](diffhunk://#diff-5b4e9ffba3afeab32b06c24f4f10c943e748555914067b383bbe00ee90685bc8L49-R49): Updated the `MirageConfigActionManager` class to use `committee_index` instead of `group_index` in its initialization and methods like `upstream_config`. [[1]](diffhunk://#diff-5b4e9ffba3afeab32b06c24f4f10c943e748555914067b383bbe00ee90685bc8L49-R49) [[2]](diffhunk://#diff-5b4e9ffba3afeab32b06c24f4f10c943e748555914067b383bbe00ee90685bc8L60-R60) [[3]](diffhunk://#diff-5b4e9ffba3afeab32b06c24f4f10c943e748555914067b383bbe00ee90685bc8L118-R131) [[4]](diffhunk://#diff-5b4e9ffba3afeab32b06c24f4f10c943e748555914067b383bbe00ee90685bc8L142-R143)

### Introduction of `is_committee_node`:

* [`core/config/mirage/committee.py`](diffhunk://#diff-24bfe87f04035ee13fe496b972896ef7f29297bc042e84569a5391d28151390bL72-R97): Modified the `generate_committee_bls_key` and `generate_committee_info` functions to include `is_committee_node`, determining whether a node is part of the active committee. This change also affects the handling of passive nodes. [[1]](diffhunk://#diff-24bfe87f04035ee13fe496b972896ef7f29297bc042e84569a5391d28151390bL72-R97) [[2]](diffhunk://#diff-24bfe87f04035ee13fe496b972896ef7f29297bc042e84569a5391d28151390bR114-R139)

* [`core/config/mirage/mirage_chain_node.py`](diffhunk://#diff-5f788a8210621cd0012e9e75a88b9af3de12fe0483f120df48e2172c7d3e5eadL53-R60): Updated the `generate_mirage_chain_nodes` function to use `is_committee_node` for determining the BLS public keys of nodes.

* [`core/config/mirage/node_info.py`](diffhunk://#diff-ff35d74e85d73fa8719e9b8df449a0017888482c0b8b8896c5bc71851c16a545L35-R35): Replaced `sync_node` with `is_committee_node` in the `MirageCurrentNodeInfo` class and its associated functions, ensuring correct behavior for committee and non-committee nodes. [[1]](diffhunk://#diff-ff35d74e85d73fa8719e9b8df449a0017888482c0b8b8896c5bc71851c16a545L35-R35) [[2]](diffhunk://#diff-ff35d74e85d73fa8719e9b8df449a0017888482c0b8b8896c5bc71851c16a545L45-R53) [[3]](diffhunk://#diff-ff35d74e85d73fa8719e9b8df449a0017888482c0b8b8896c5bc71851c16a545L61-R62) [[4]](diffhunk://#diff-ff35d74e85d73fa8719e9b8df449a0017888482c0b8b8896c5bc71851c16a545L73-R74)

### Adjustments to Mirage configuration pipeline:

* [`core/monitor/mirage/monitor_config.py`](diffhunk://#diff-6ceb24f9ea1db5fcd0b488c99344505e5271ca6552d3291fd2d08d27359e0c57L48-R55): Incorporated `committee_index` and `is_committee_node` into the configuration pipeline, using Mirage Manager methods to determine the active committee index and node membership.

### Other updates:

* Updated imports across multiple files to include `CommitteeIndex`, `NodeId`, and related types from `skale.types.committee`. [[1]](diffhunk://#diff-4e4da57fbad98223f9a788306d5c499c3ba49e9507e5fd1df8e16d8de19d3dc3R26) [[2]](diffhunk://#diff-24bfe87f04035ee13fe496b972896ef7f29297bc042e84569a5391d28151390bR24-R25) [[3]](diffhunk://#diff-a1097d90cc648485aae88e7f9bfb6477dcc644e60d6239ba1e32db0be4ce16acR32) [[4]](diffhunk://#diff-5b4e9ffba3afeab32b06c24f4f10c943e748555914067b383bbe00ee90685bc8R23)

These changes collectively enhance the clarity, flexibility, and functionality of the Mirage system by aligning terminology and introducing new capabilities for committee-based configurations.