### PR TITLE
Improve skaled scheduler, update monitors logic

### DIFF
--- a/core/monitor/fair/action_skaled.py
+++ b/core/monitor/fair/action_skaled.py
@@ -43,6 +43,7 @@ from core.node_config import NodeConfig
 from core.schains.cleaner import remove_skaled_container
 from core.types.chain import FairChainName
 from tools.configs.containers import SKALED_CONTAINER, SKALED_RESTART_DELAY_SECONDS
+from tools.configs.fair import SKALED_RESTART_JOB_NAME
 from tools.docker_utils import DockerUtils
 from tools.node_options import NodeOptions
 
@@ -50,6 +51,9 @@ logger = logging.getLogger(__name__)
 
 
 class FairSkaledActionManager(BaseSkaledActionManager):
+    checks: SkaledChecks
+    rule_controller: FairCommitteeScopeRuleController
+
     def __init__(
         self,
         chain_name: FairChainName,
@@ -74,13 +78,11 @@ class FairSkaledActionManager(BaseSkaledActionManager):
     @BaseActionManager.monitor_block
     def skaled_container(
         self,
+        download_snapshot: bool = False,
+        passive_node: bool = False,
         abort_on_exit: bool = True,
     ) -> bool:
-        sync_node = False  # todod: tmp, handle it later
-
-        download_snapshot = False
         snapshot_from = None
-
         if self.chain_record.snapshot_from:
             logger.info(
                 'Skaled start mode: snapshot, snapshot_from: %s', self.chain_record.snapshot_from
@@ -99,7 +101,7 @@ class FairSkaledActionManager(BaseSkaledActionManager):
             snapshot_from=snapshot_from,
             abort_on_exit=abort_on_exit,
             dutils=self.dutils,
-            sync_node=sync_node,  # todod: tmp, handle it later - skaled should be fixed
+            sync_node=passive_node,
             historic_state=self.node_options.historic_state,
         )
         time.sleep(CONTAINER_POST_RUN_DELAY)
@@ -124,6 +126,7 @@ class FairSkaledActionManager(BaseSkaledActionManager):
             remove_skaled_container(self.name, dutils=self.dutils)
         self.chain_record.set_restart_count(0)
         self.chain_record.set_failed_rpc_count(0)
+        self.chain_record.set_restart_ts(0)
         self.skaled_container(abort_on_exit=abort_on_exit)
         return initial_status
 
@@ -146,8 +149,6 @@ class FairSkaledActionManager(BaseSkaledActionManager):
     @BaseActionManager.monitor_block
     def schedule_skaled_restart(self, last_group_start_timestamp: int) -> bool:
         logger.info('Scheduling skaled restart')
-        # TODOD: add more robust way to ensure that skaled is always restarted:
-        # save to redis and read to ensure that skaled is always restarted
         earliest_possible_restart_ts = int(time.time())
         latest_possible_restart_ts = last_group_start_timestamp - SKALED_RESTART_DELAY_SECONDS
         logger.info(
@@ -160,10 +161,14 @@ class FairSkaledActionManager(BaseSkaledActionManager):
             earliest_possible_restart_ts, latest_possible_restart_ts
         )
         self.chain_record.set_restart_ts(restart_ts)
-        logger.info('Scheduling skaled restart at %d', restart_ts)
+        logger.info(
+            'Scheduling skaled restart at %d, job id: %s', restart_ts, SKALED_RESTART_JOB_NAME
+        )
         self.scheduler.add_job(
             func=self.recreated_schain_containers,
             trigger='date',
             run_date=datetime.fromtimestamp(restart_ts, tz=timezone.utc),
+            id=SKALED_RESTART_JOB_NAME,
+            name='skaled restart job',
         )
         return True

--- a/core/monitor/fair/healthcheck.py
+++ b/core/monitor/fair/healthcheck.py
@@ -22,6 +22,10 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 from skale import FairManager
 from skale.transactions.exceptions import TransactionError
+from tools.configs.fair import (
+    HEALTHCHECK_JOB_NAME,
+    SAFE_HEARTBEAT_BUFFER,
+)
 from tools.exceptions import LocalEndpointUnreachableError
 
 from core.node_config import NodeConfig
@@ -29,8 +33,6 @@ from core.utils.fair import init_local_fair
 
 
 logger = logging.getLogger(__name__)
-BACKGROUND_JOB_NAME = 'fair_healthcheck'
-INTERVAL_BUFFER = 30
 
 
 def healthcheck_job(
@@ -49,22 +51,27 @@ def handle_healthcheck_job(
     node_config: NodeConfig,
 ) -> None:
     try:
-        job = scheduler.get_job(BACKGROUND_JOB_NAME)
+        job = scheduler.get_job(HEALTHCHECK_JOB_NAME)
         if job is None:
             local_fair = init_local_fair(node_config)
             logger.info('Going to execute healthcheck job')
             healthcheck_job(local_fair)
             logger.info('Adding healthcheck job to the scheduler')
             heartbeat_interval = local_fair.status.heartbeat_interval()
-            safe_heartbeat_interval = heartbeat_interval - INTERVAL_BUFFER
+            safe_heartbeat_interval = heartbeat_interval - SAFE_HEARTBEAT_BUFFER
             logger.info(f'Healthcheck job will run every {heartbeat_interval} seconds')
+            logger.info(
+                'Scheduling healthcheck job, interval: %d seconds, job id: %s',
+                safe_heartbeat_interval,
+                HEALTHCHECK_JOB_NAME,
+            )
             scheduler.add_job(
                 func=healthcheck_job,
                 args=[local_fair],
                 trigger='interval',
                 seconds=safe_heartbeat_interval,
-                id=BACKGROUND_JOB_NAME,
-                name='Fair Healthcheck Job',
+                id=HEALTHCHECK_JOB_NAME,
+                name='fair healthcheck job',
             )
             scheduler.start()
             logger.info('Healthcheck scheduler started - jobs will now execute')

--- a/core/monitor/fair/monitor_skaled.py
+++ b/core/monitor/fair/monitor_skaled.py
@@ -19,7 +19,7 @@
 
 import logging
 import time
-from typing import Type
+from typing import Type, cast
 
 from apscheduler.schedulers.background import BackgroundScheduler
 
@@ -35,6 +35,7 @@ from core.node_config import NodeConfig
 from core.redis.chain_record import ChainRecord
 from core.types.chain import FairChainName
 from tools.configs import SYNC_NODE
+from tools.configs.fair import SKALED_RESTART_JOB_NAME
 from tools.docker_utils import DockerUtils
 from tools.helper import no_hyphens
 from tools.notifications.messages import notify_checks
@@ -89,8 +90,7 @@ def run_skaled_pipeline(
     notify_checks(chain_name, node_config.all(), api_status)
 
     logger.info('Skaled check status: %s', check_status)
-
-    logger.info('Upstream config %s', skaled_am.upstream_config_path)
+    logger.info('Upstream config: %s', skaled_am.upstream_config_path)
 
     mon = get_skaled_monitor(
         action_manager=skaled_am,
@@ -116,12 +116,12 @@ class BaseFairSkaledMonitor(BaseSkaledMonitor):
 
     @property
     def checks(self) -> SkaledChecks:
-        return self._checks
+        return cast(SkaledChecks, self._checks)
 
 
 class RegularSkaledMonitor(BaseFairSkaledMonitor):
     def execute(self) -> None:
-        if not self._checks.committee_scope_firewall_rules:
+        if not self.checks.committee_scope_firewall_rules:
             self._am.committee_scope_firewall_rules()
         if not self.checks.volume:
             self._am.volume()
@@ -142,14 +142,12 @@ class NoConfigSkaledMonitor(BaseFairSkaledMonitor):
             logger.debug('Waiting for upstream config')
 
 
-class ActiveSkaledMonitor(BaseFairSkaledMonitor):
+class StartupSkaledMonitor(BaseFairSkaledMonitor):
     def execute(self) -> None:
         if not self.checks.volume:
             self._am.volume()
         if not self.checks.skaled_container:
-            # TODOD: handle download snapshot - skaled should be fixed
-            # self._am.skaled_container(download_snapshot=True)
-            self._am.skaled_container()
+            self._am.skaled_container(download_snapshot=True)
         else:
             self._am.reset_restart_counter()
         if not self.checks.rpc:
@@ -178,39 +176,16 @@ def get_skaled_monitor(
 
     mon_type: Type[BaseFairSkaledMonitor] = RegularSkaledMonitor
 
-    # todod: check if the node of a part of the CURRENT/NEXT committee - optimize
-    config = action_manager.cfm.skaled_config
-    current_ts = int(time.time())
-    own_ip = get_own_ip_from_config(config, current_ts)
-    in_current_committee = own_ip is not None
+    if chain_record.restart_ts != 0 and not action_manager.scheduler.get_job(
+        SKALED_RESTART_JOB_NAME
+    ):
+        logger.warning('Chain record restart timestamp is not zero and no restart job found')
+        mon_type = UpdateConfigSkaledMonitor
 
     if not check_status['config']:
         mon_type = NoConfigSkaledMonitor
+    elif not check_status['volume']:
+        mon_type = StartupSkaledMonitor
     elif not check_status['config_updated']:
         mon_type = UpdateConfigSkaledMonitor
-    elif not in_current_committee:
-        mon_type = ActiveSkaledMonitor
-
-    # if SYNC_NODE:
-    #     # todod: implement sync node monitors
-    #     return mon_type
-
-    # todod: implement regular node monitors
-
-    # if not check_status['config']:
-    #     mon_type = NoConfigSkaledMonitor
-    # elif is_backup_mode(schain_record):
-    #     mon_type = BackupSkaledMonitor
-    # elif is_repair_mode(schain_record, check_status, skaled_status, ncli_status, automatic_repair): # noqa: E501
-    #     mon_type = RepairSkaledMonitor
-    # elif is_recreate_mode(check_status, schain_record):
-    #     mon_type = RecreateSkaledMonitor
-    # elif is_new_node_mode(schain_record, action_manager.finish_ts):
-    #     mon_type = NewNodeSkaledMonitor
-    # elif is_config_update_time(check_status, skaled_status):
-    #     mon_type = UpdateConfigSkaledMonitor
-    # elif is_reload_group_mode(check_status, action_manager.upstream_finish_ts):
-    #     mon_type = ReloadGroupSkaledMonitor
-    # elif is_reload_ip_mode(check_status, action_manager.econfig.reload_ts):
-    #     mon_type = ReloadIpSkaledMonitor
     return mon_type

--- a/core/monitor/fair/monitor_skaled.py
+++ b/core/monitor/fair/monitor_skaled.py
@@ -18,7 +18,6 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-import time
 from typing import Type, cast
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -27,7 +26,6 @@ from core.chain.status import SkaledStatus, get_skaled_status
 from core.checks.base import TG_ALLOWED_CHECKS, get_api_checks_status
 from core.checks.fair import SkaledChecks
 from core.config.fair.committee_nodes import get_last_group_start_timestamp_from_config
-from core.config.fair.firewall import get_own_ip_from_config
 from core.firewall.utils import get_fair_committee_scope_rule_controller
 from core.monitor.fair.action_skaled import FairSkaledActionManager
 from core.monitor.monitor_base import BaseSkaledMonitor

--- a/fair.py
+++ b/fair.py
@@ -23,10 +23,12 @@ import logging
 from filelock import FileLock
 from apscheduler.schedulers.background import BackgroundScheduler
 
+from core.config.schain.static_params import get_fair_chain_name
 from core.monitoring import update_monitoring_services
 from core.node_config import NodeConfig
 
 from core.monitor.fair.main import start_tasks
+from core.redis.chain_record import ChainRecord
 from core.redis.migrations import run_redis_migrations
 
 from tools.configs import INIT_LOCK_PATH
@@ -52,6 +54,13 @@ def monitor(node_config: NodeConfig) -> None:
         time.sleep(SLEEP_INTERVAL)
 
 
+def update_chain_record() -> None:
+    logger.info('Updating chain record during fair admin startup')
+    chain_name = get_fair_chain_name()
+    chain_record = ChainRecord(chain_name)
+    chain_record.set_first_run(True)
+
+
 def worker() -> None:
     node_config = NodeConfig()
     while node_config.id is None:
@@ -59,6 +68,7 @@ def worker() -> None:
         time.sleep(SLEEP_INTERVAL)
 
     update_monitoring_services(node_config.ip, node_config.id, fair_contracts())
+    update_chain_record()
     monitor(node_config)
 
 

--- a/tools/configs/fair.py
+++ b/tools/configs/fair.py
@@ -2,3 +2,7 @@ import os
 
 NFT_NETWORK_SCOPE_CHAIN = os.getenv('NFTABLES_NETWORK_SCOPE_CHAIN', 'network')
 NFT_COMMITTEE_SCOPE_CHAIN = os.getenv('NFTABLES_COMMITTEE_SCOPE_CHAIN', 'committee')
+
+HEALTHCHECK_JOB_NAME = 'fair_healthcheck_job'
+SKALED_RESTART_JOB_NAME = 'fair_skaled_restart_job'
+SAFE_HEARTBEAT_BUFFER = 30


### PR DESCRIPTION
This pull request introduces enhancements to the monitoring and scheduling logic for the Fair Skaled system, focusing on improving job management, configuration handling, and startup procedures. Key changes include the addition of new constants for job names and buffer intervals, updates to chain record management, and improvements to the monitoring pipeline logic.

### Monitoring and Scheduling Enhancements:
* Added `SKALED_RESTART_JOB_NAME` and `HEALTHCHECK_JOB_NAME` constants to uniquely identify jobs in the scheduler for better tracking and logging. (`tools/configs/fair.py` - [tools/configs/fair.pyR5-R8](diffhunk://#diff-8d9f68a2c5546c9f3eecf975e4f7fc632730c01bc4608668e90745841eac1086R5-R8))
* Updated healthcheck job scheduling to use `HEALTHCHECK_JOB_NAME` and `SAFE_HEARTBEAT_BUFFER` for improved clarity and configurability. (`core/monitor/fair/healthcheck.py` - [[1]](diffhunk://#diff-16322cdfa0be105dfae6bcc182df444d14ceea8bcfe845eae3639028205b2477R25-L33) [[2]](diffhunk://#diff-16322cdfa0be105dfae6bcc182df444d14ceea8bcfe845eae3639028205b2477L52-R74)
* Enhanced Skaled restart scheduling with job IDs and improved logging for restart timestamps. (`core/monitor/fair/action_skaled.py` - [core/monitor/fair/action_skaled.pyL163-R172](diffhunk://#diff-1596260e33de89fdfcd4cec0e3d16bb4fe2adf6b1649a8924aeac66e9da453dcL163-R172))

### Chain Record Management:
* Introduced `update_chain_record` function to set the `first_run` flag during Fair admin startup, ensuring proper initialization of chain records. (`fair.py` - [fair.pyR57-R71](diffhunk://#diff-8a49e327b6ec59c342a7cfc98be616962f5f4e857f98e9ef8bde9a301a634822R57-R71))
* Added `set_restart_ts(0)` to reset the restart timestamp when recreating Skaled containers. (`core/monitor/fair/action_skaled.py` - [core/monitor/fair/action_skaled.pyR129](diffhunk://#diff-1596260e33de89fdfcd4cec0e3d16bb4fe2adf6b1649a8924aeac66e9da453dcR129))

### Monitoring Pipeline Improvements:
* Refactored the `get_skaled_monitor` function to handle scenarios where restart jobs are missing and added logic to select appropriate monitor types based on startup and volume checks. (`core/monitor/fair/monitor_skaled.py` - [core/monitor/fair/monitor_skaled.pyL181-L215](diffhunk://#diff-d88c7ce540726526315a6fd610ce5ad7e4a2bb25e48f93562b68cfc209e44f8dL181-L215))
* Renamed `ActiveSkaledMonitor` to `StartupSkaledMonitor` and enabled snapshot downloads during Skaled container initialization. (`core/monitor/fair/monitor_skaled.py` - [core/monitor/fair/monitor_skaled.pyL145-R150](diffhunk://#diff-d88c7ce540726526315a6fd610ce5ad7e4a2bb25e48f93562b68cfc209e44f8dL145-R150))

These changes collectively improve the reliability and maintainability of the Fair Skaled monitoring system while providing clearer job identification and enhanced initialization procedures.