### PR TITLE
Add `change-ip` route

### DIFF
--- a/web/routes/fair_node.py
+++ b/web/routes/fair_node.py
@@ -100,3 +100,32 @@ def set_domain_name():
             msg=f'Error setting domain name: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
         )
     return construct_ok_response()
+
+
+@fair_node_bp.route(get_api_url(BLUEPRINT_NAME, 'change-ip'), methods=['POST'])
+@g_fair
+def change_ip():
+    logger.debug(request)
+    if not request.json:
+        abort(400)
+
+    ip = request.json.get('ip')
+    port = request.json.get('port')
+
+    fair: FairManager = g.fair
+    node_config: NodeConfig = g.config
+
+    if not node_config.id:
+        return construct_err_response(
+            msg='Node is not registered', status_code=HTTPStatus.BAD_REQUEST
+        )
+
+    try:
+        fair.nodes.set_ip_address(node_config.id, ip, port)
+    except TransactionError as e:
+        logger.error(f'Error setting IP address: {e}')
+        return construct_err_response(
+            msg=f'Error setting IP address: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+    node_config.ip = ip
+    return construct_ok_response()


### PR DESCRIPTION
This pull request adds a new endpoint to the `fair_node` blueprint for changing the IP address of a node. The most important change introduces the `change_ip` function, which handles the IP change logic and ensures proper error handling.

### New functionality:
* Added the `change_ip` endpoint to the `fair_node` blueprint (`@fair_node_bp.route(get_api_url(BLUEPRINT_NAME, 'change-ip'), methods=['POST'])`). This endpoint allows updating the IP address of a node.

### Error handling:
* Implemented validation to check if the request body contains JSON and if the node is registered before proceeding with the IP change.
* Added exception handling for `TransactionError` to log errors and return appropriate error responses when setting the IP address fails.