### PR TITLE
Add API route for node exit on fair

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ websocket-client==1.8.0
 
 requests==2.32.4
 
-skale.py==7.3dev3
+skale.py==7.3dev4
 
 ima-predeployed==2.1.0b0
 etherbase-predeployed==1.1.0b3

--- a/web/routes/fair_node.py
+++ b/web/routes/fair_node.py
@@ -120,6 +120,11 @@ def change_ip():
             msg='Node is not registered', status_code=HTTPStatus.BAD_REQUEST
         )
 
+    if fair.committee.is_node_in_current_or_next_committee(node_config.id):
+        return construct_err_response(
+            msg='Node is in current or next committee', status_code=HTTPStatus.BAD_REQUEST
+        )
+
     try:
         fair.nodes.set_ip_address(node_config.id, ip, port)
     except TransactionError as e:
@@ -128,4 +133,32 @@ def change_ip():
             msg=f'Error setting IP address: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
         )
     node_config.ip = ip
+    return construct_ok_response()
+
+
+@fair_node_bp.route(get_api_url(BLUEPRINT_NAME, 'exit'), methods=['POST'])
+@g_fair
+def exit():
+    logger.debug(request)
+
+    fair: FairManager = g.fair
+    node_config: NodeConfig = g.config
+
+    if not node_config.id:
+        return construct_err_response(
+            msg='Node is not registered', status_code=HTTPStatus.BAD_REQUEST
+        )
+
+    if fair.committee.is_node_in_current_or_next_committee(node_config.id):
+        return construct_err_response(
+            msg='Node is in current or next committee', status_code=HTTPStatus.BAD_REQUEST
+        )
+
+    try:
+        fair.nodes.delete_node(node_config.id)
+    except TransactionError as e:
+        logger.error(f'Error deleting node: {e}')
+        return construct_err_response(
+            msg=f'Error deleting node: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+        )
     return construct_ok_response()


### PR DESCRIPTION
This pull request introduces a new route for handling node exits and adds validation to prevent certain operations on nodes currently in or scheduled for a committee. The key changes include adding a new `exit` endpoint and enhancing the `change_ip` function with additional checks.

### Enhancements to node operations:

* **Validation in `change_ip`:**
  - Added a check to prevent IP address changes for nodes that are part of the current or next committee. (`web/routes/fair_node.py`, [web/routes/fair_node.pyR123-R127](diffhunk://#diff-1a6585bbd4717824076a6426249e125d81d8eecd54617e196145eb71e009d35eR123-R127))

* **New `exit` endpoint:**
  - Introduced a `POST` route (`/exit`) to allow nodes to exit the system.
  - This endpoint validates that the node is not in the current or next committee before proceeding with the deletion.
  - Handles errors during node deletion and logs them appropriately. (`web/routes/fair_node.py`, [web/routes/fair_node.pyR137-R164](diffhunk://#diff-1a6585bbd4717824076a6426249e125d81d8eecd54617e196145eb71e009d35eR137-R164))