### PR TITLE
Update watchdog apis

### DIFF
--- a/tests/routes/health_test.py
+++ b/tests/routes/health_test.py
@@ -1,6 +1,6 @@
 import mock
 import pytest
-from time import sleep
+
 
 from flask import Flask, appcontext_pushed, g
 
@@ -12,7 +12,7 @@ from web.models.schain import SChainRecord
 from web.routes.health import health_bp
 from web.helper import get_api_url
 
-from tests.utils import get_bp_data, get_schain_struct, run_custom_schain_container
+from tests.utils import get_bp_data, get_schain_struct
 
 
 TEST_SGX_KEYNAME = 'test_keyname'
@@ -55,34 +55,6 @@ def unregistered_skale_bp(skale, dutils):
             yield app.test_client()
         finally:
             SChainRecord.drop_table()
-
-
-def test_containers(skale_bp, dutils):
-    data = get_bp_data(skale_bp, get_api_url('health', 'containers'))
-    expected = {
-        'status': 'ok',
-        'payload': dutils.get_containers_info(all=False, name_filter='', format=True),
-    }
-    assert data == expected
-    for container_info in data['payload']:
-        field_map = {'cpu_shares': 0, 'mem_limit': 0, 'swap_limit': 0, 'swappiness': None}
-        for field in field_map.keys():
-            assert field in container_info
-
-
-def test_containers_all(skale_bp, dutils, schain_db, cleanup_schain_containers):
-    run_custom_schain_container(dutils, schain_db, 'bash -c "exit 1"')
-    sleep(10)
-    data = get_bp_data(skale_bp, get_api_url('health', 'containers'), params={'all': True})
-    expected = {
-        'status': 'ok',
-        'payload': dutils.get_containers_info(all=True, name_filter='', format=True),
-    }
-    assert data == expected
-    for container_info in data['payload']:
-        field_map = {'cpu_shares': 0, 'mem_limit': 0, 'swap_limit': 0, 'swappiness': None}
-        for field in field_map.keys():
-            assert field in container_info
 
 
 def test_schains_checks(skale_bp, skale, schain_on_contracts, schain_db, dutils):

--- a/tests/routes/info_test.py
+++ b/tests/routes/info_test.py
@@ -1,5 +1,5 @@
 import pytest
-
+from time import sleep
 from flask import Flask, appcontext_pushed, g
 from sgx import SgxClient
 
@@ -11,7 +11,7 @@ from web.models.schain import SChainRecord
 from web.routes.info import info_bp
 from web.helper import get_api_url
 
-from tests.utils import get_bp_data
+from tests.utils import get_bp_data, run_custom_schain_container
 
 
 TEST_SGX_KEYNAME = 'test_keyname'
@@ -97,3 +97,31 @@ def test_btrfs_info(skale_bp, skale):
     assert data['status'] == 'ok'
     payload = data['payload']
     assert payload['kernel_module'] is True
+
+
+def test_containers(skale_bp, dutils):
+    data = get_bp_data(skale_bp, get_api_url('info', 'containers'))
+    expected = {
+        'status': 'ok',
+        'payload': dutils.get_containers_info(all=False, name_filter='', format=True),
+    }
+    assert data == expected
+    for container_info in data['payload']:
+        field_map = {'cpu_shares': 0, 'mem_limit': 0, 'swap_limit': 0, 'swappiness': None}
+        for field in field_map.keys():
+            assert field in container_info
+
+
+def test_containers_all(skale_bp, dutils, schain_db, cleanup_schain_containers):
+    run_custom_schain_container(dutils, schain_db, 'bash -c "exit 1"')
+    sleep(10)
+    data = get_bp_data(skale_bp, get_api_url('info', 'containers'), params={'all': True})
+    expected = {
+        'status': 'ok',
+        'payload': dutils.get_containers_info(all=True, name_filter='', format=True),
+    }
+    assert data == expected
+    for container_info in data['payload']:
+        field_map = {'cpu_shares': 0, 'mem_limit': 0, 'swap_limit': 0, 'swappiness': None}
+        for field in field_map.keys():
+            assert field in container_info

--- a/web/helper.py
+++ b/web/helper.py
@@ -29,8 +29,8 @@ from skale.utils.web3_utils import init_web3
 
 from core.node_config import NodeConfig
 from core.utils.fair import init_fair_manager
-from tools.configs.web3 import endpoint
-from tools.helper import init_skale
+from tools.configs.web3 import boot_endpoint, endpoint
+from tools.helper import init_skale, is_fair
 from tools.wallet_utils import init_wallet
 from web import API_VERSION_PREFIX
 
@@ -71,7 +71,10 @@ def init_skale_from_node_config(node_config: NodeConfig) -> SkaleManager:
 def g_web3(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        g.web3 = init_web3(endpoint())
+        if is_fair():
+            g.web3 = init_web3(boot_endpoint())
+        else:
+            g.web3 = init_web3(endpoint())
         return func(*args, **kwargs)
 
     return wrapper

--- a/web/routes/health.py
+++ b/web/routes/health.py
@@ -41,17 +41,6 @@ BLUEPRINT_NAME = 'health'
 health_bp = Blueprint(BLUEPRINT_NAME, __name__)
 
 
-@health_bp.route(get_api_url(BLUEPRINT_NAME, 'containers'), methods=['GET'])
-def containers():
-    logger.debug(request)
-    all = request.args.get('all') == 'True'
-    name_filter = request.args.get('name_filter') or ''
-    containers_list = g.docker_utils.get_containers_info(
-        all=all, name_filter=name_filter, format=True
-    )
-    return construct_ok_response(containers_list)
-
-
 @health_bp.route(get_api_url(BLUEPRINT_NAME, 'schains'), methods=['GET'])
 @g_skale
 def schains_checks():

--- a/web/routes/info.py
+++ b/web/routes/info.py
@@ -25,8 +25,8 @@ from sgx import SgxClient
 from core.node import get_check_report
 from core.node import get_meta_info, get_node_hardware_info, get_btrfs_info
 
-from tools.helper import get_endpoint_call_speed
-from tools.configs.web3 import ENDPOINT, UNTRUSTED_PROVIDERS
+from tools.helper import get_endpoint_call_speed, is_fair
+from tools.configs.web3 import BOOT_ENDPOINT, ENDPOINT, UNTRUSTED_PROVIDERS
 from tools.sgx_utils import SGX_CERTIFICATES_FOLDER, SGX_SERVER_URL
 
 from web.helper import construct_ok_response, get_api_url, g_web3
@@ -51,7 +51,8 @@ def endpoint_info():
     logger.debug(request)
     call_speed = get_endpoint_call_speed(g.web3)
     block_number = g.web3.eth.block_number
-    trusted = not any([untrusted in ENDPOINT for untrusted in UNTRUSTED_PROVIDERS])
+    endpoint = BOOT_ENDPOINT if is_fair() else ENDPOINT
+    trusted = not any([untrusted in endpoint for untrusted in UNTRUSTED_PROVIDERS])
     try:
         eth_client_version = g.web3.client_version
     except Exception:
@@ -128,3 +129,14 @@ def check_report():
     logger.debug(request)
     report = get_check_report()
     return construct_ok_response(data=report)
+
+
+@info_bp.route(get_api_url(BLUEPRINT_NAME, 'containers'), methods=['GET'])
+def containers():
+    logger.debug(request)
+    all = request.args.get('all') == 'True'
+    name_filter = request.args.get('name_filter') or ''
+    containers_list = g.docker_utils.get_containers_info(
+        all=all, name_filter=name_filter, format=True
+    )
+    return construct_ok_response(containers_list)


### PR DESCRIPTION
This pull request moves the `/containers` endpoint from the `health` blueprint to the `info` blueprint, updates related tests, and improves endpoint selection logic based on the environment. The changes help clarify API responsibilities and ensure that "fair" mode uses the correct web3 endpoint.

**API endpoint changes:**

* Removed the `/containers` route from the `health` blueprint by deleting its handler from `web/routes/health.py`.
* Added the `/containers` route to the `info` blueprint in `web/routes/info.py`, including a new handler that returns container information.

**Test updates:**

* Moved container-related tests from `tests/routes/health_test.py` to `tests/routes/info_test.py`, ensuring tests are aligned with the new endpoint location. [[1]](diffhunk://#diff-b71b571e33fb4636e39859c24a64787f2ba485305a34f3dd3846c3b0c86ce5b3L60-L87) [[2]](diffhunk://#diff-28e12a5ef9c477de7d4533e48eec7c88185b8056242b5a39cebc684c9c93aa1fR100-R127)
* Updated imports in test files to reflect the new location of utility functions and removed unused imports. [[1]](diffhunk://#diff-b71b571e33fb4636e39859c24a64787f2ba485305a34f3dd3846c3b0c86ce5b3L3-R3) [[2]](diffhunk://#diff-b71b571e33fb4636e39859c24a64787f2ba485305a34f3dd3846c3b0c86ce5b3L15-R15) [[3]](diffhunk://#diff-28e12a5ef9c477de7d4533e48eec7c88185b8056242b5a39cebc684c9c93aa1fL2-R2) [[4]](diffhunk://#diff-28e12a5ef9c477de7d4533e48eec7c88185b8056242b5a39cebc684c9c93aa1fL14-R14)

**Web3 endpoint selection improvements:**

* Updated `web/helper.py` to use `boot_endpoint()` when running in "fair" mode, otherwise defaulting to `endpoint()`. [[1]](diffhunk://#diff-6418141891183454aa16f91fd5d0fab69b869950772a5a5050f398a88c8f7cfeL32-R33) [[2]](diffhunk://#diff-6418141891183454aa16f91fd5d0fab69b869950772a5a5050f398a88c8f7cfeR74-R76)
* Modified `web/routes/info.py` to select the correct endpoint and trusted status depending on whether "fair" mode is active. [[1]](diffhunk://#diff-aea2d6419c84bd24f5e0bd19ac753989e9f3219e443ea684b33f6eb40d56948aL28-R29) [[2]](diffhunk://#diff-aea2d6419c84bd24f5e0bd19ac753989e9f3219e443ea684b33f6eb40d56948aL54-R55)