### PR TITLE
Add staking address to nodes section

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,10 @@ jobs:
       - name: Checking formatting with ruff
         run: uv run ruff check
 
+      - name: Run sgx wallet sim
+        run: |
+          bash ./scripts/run_sgxwallet.sh
+
       - name: Deploy manager
         run: |
           bash ./helper-scripts/deploy_manager.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Checking formatting with ruff
         run: uv run ruff check
 
+      - name: Run sgx wallet sim
+        run: |
+          bash ./scripts/run_sgxwallet.sh
+
       - name: Deploy skaled
         run: |
           bash ./scripts/run_skaled.sh

--- a/core/config/fair/committee.py
+++ b/core/config/fair/committee.py
@@ -21,8 +21,8 @@ from dataclasses import dataclass
 from typing import Dict
 
 from skale.types.committee import CommitteeGroup
+from skale.types.dkg import DkgId, G2Point
 from skale.types.node import NodeId
-from skale.types.dkg import G2Point, DkgId
 
 from core.config.fair.fair_chain_node import FairChainNodeInfo, generate_fair_chain_nodes
 from core.config.schain.static_params import get_fair_chain_name
@@ -68,11 +68,13 @@ class BlsKey:
 @dataclass
 class CommitteeInfo:
     bls_key: BlsKey
+    staking_contract_address: str
     group: list[FairChainNodeInfo]
 
     def to_dict(self) -> dict:
         return {
             'blsKey': self.bls_key.to_dict(),
+            'staking_contract_address': self.staking_contract_address,
             'group': [node.to_dict() for node in self.group],
         }
 
@@ -125,6 +127,7 @@ def generate_committee_info(
         committee_group = committee['group']
         index = committee['index']
         dkg_id = committee['committee'].dkg_id
+        staking_contract_address = committee['staking_contract_address']
 
         is_committee_node = any(node.id == node_id for node in committee_group)
         common_bls_public_key = committee['committee'].common_public_key
@@ -138,6 +141,10 @@ def generate_committee_info(
         )
 
         fair_chain_nodes = generate_fair_chain_nodes(committee_group, dkg_id, is_committee_node)
-        committee_info[ts] = CommitteeInfo(bls_key=bls_key, group=fair_chain_nodes)
+        committee_info[ts] = CommitteeInfo(
+            bls_key=bls_key,
+            group=fair_chain_nodes,
+            staking_contract_address=staking_contract_address,
+        )
 
     return committee_info

--- a/core/config/fair/committee.py
+++ b/core/config/fair/committee.py
@@ -74,7 +74,7 @@ class CommitteeInfo:
     def to_dict(self) -> dict:
         return {
             'blsKey': self.bls_key.to_dict(),
-            'staking_contract_address': self.staking_contract_address,
+            'stakingContractAddress': self.staking_contract_address,
             'group': [node.to_dict() for node in self.group],
         }
 

--- a/core/config/fair/generator.py
+++ b/core/config/fair/generator.py
@@ -25,13 +25,11 @@ from typing import Dict
 
 from skale import FairManager
 from skale.fair_config import generate_committee_history, get_nodes_from_last_two_committees
-from skale.types.committee import CommitteeGroup
+from skale.types.committee import Committee, CommitteeGroup, CommitteeIndex, Timestamp
+from skale.types.dkg import DkgId, Fp2Point, G2Point
 from skale.types.node import FairNode, FairNodeWithRewardWalletAddress, NodeId, NodeWithSchains
 from skale.types.node import Node as SkaleNode
 from skale.types.rotation import NodesGroup
-from skale.types.committee import CommitteeIndex, Timestamp, Committee
-from skale.types.dkg import G2Point, DkgId, Fp2Point
-
 from skale.utils.web3_utils import public_key_to_address, to_checksum_address
 
 from core.config.base import FairConfig, SChainBaseConfig
@@ -45,8 +43,8 @@ from core.config.schain.static_params import (
     get_static_schain_info_fair,
 )
 from tools.configs.schains import FAIR_BASE_SCHAIN_CONFIG_FILEPATH
-from tools.helper import cast_manager_to_fair_node_id
 from tools.configs.web3 import ZERO_ADDRESS
+from tools.helper import cast_manager_to_fair_node_id
 
 logger = logging.getLogger(__name__)
 
@@ -88,8 +86,7 @@ def generate_fair_config_with_manager(
 
 
 def skale_node_to_fair_node_adapter(
-    skale_node: SkaleNode,
-    node_id: NodeId
+    skale_node: SkaleNode, node_id: NodeId
 ) -> FairNodeWithRewardWalletAddress:
     return FairNodeWithRewardWalletAddress(
         id=node_id,
@@ -127,6 +124,7 @@ def generate_fair_config_adapter(
         {
             'ts': Timestamp(0),
             'index': CommitteeIndex(0),
+            'staking_contract_address': to_checksum_address(ZERO_ADDRESS),
             'group': committee_nodes,
             'committee': Committee(
                 node_ids=[node.id for node in committee_nodes],
@@ -138,6 +136,7 @@ def generate_fair_config_adapter(
         {
             'ts': Timestamp(chain_start_ts),
             'index': CommitteeIndex(0),
+            'staking_contract_address': to_checksum_address(ZERO_ADDRESS),
             'group': committee_nodes,
             'committee': Committee(
                 node_ids=[node.id for node in committee_nodes],

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,7 @@ websocket-client==1.8.0
 
 requests==2.32.4
 
-# skale.py==7.3dev6
-git+https://github.com/skalenetwork/skale.py.git@add-staking-contract-address-to-nodes
+skale.py==7.3dev7
 
 ima-predeployed==2.1.0b0
 etherbase-predeployed==1.1.0b3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ websocket-client==1.8.0
 
 requests==2.32.4
 
-skale.py==7.3dev6
+# skale.py==7.3dev6
+git+https://github.com/skalenetwork/skale.py.git@add-staking-contract-address-to-nodes
 
 ima-predeployed==2.1.0b0
 etherbase-predeployed==1.1.0b3

--- a/scripts/run_core_tests.sh
+++ b/scripts/run_core_tests.sh
@@ -8,11 +8,11 @@ source $DIR/../helper-scripts/helper.sh
 : "${SGX_WALLET_TAG?Need to set SGX_WALLET_TAG}"
 
 tests_cleanup
-sgx_cleanup
+# sgx_cleanup
 
 export_test_env
 
-run_sgx_simulator $SGX_WALLET_TAG
+# run_sgx_simulator $SGX_WALLET_TAG
 bash scripts/run_redis.sh
 
 python -m py.test --cov-config=.coveragerc --cov=. tests --ignore=tests/firewall --ignore=tests/fair $@

--- a/scripts/run_core_tests.sh
+++ b/scripts/run_core_tests.sh
@@ -8,11 +8,9 @@ source $DIR/../helper-scripts/helper.sh
 : "${SGX_WALLET_TAG?Need to set SGX_WALLET_TAG}"
 
 tests_cleanup
-# sgx_cleanup
 
 export_test_env
 
-# run_sgx_simulator $SGX_WALLET_TAG
 bash scripts/run_redis.sh
 
 python -m py.test --cov-config=.coveragerc --cov=. tests --ignore=tests/firewall --ignore=tests/fair $@

--- a/scripts/run_fair_test.sh
+++ b/scripts/run_fair_test.sh
@@ -8,7 +8,7 @@ source $DIR/../helper-scripts/helper.sh
 : "${SGX_WALLET_TAG?Need to set SGX_WALLET_TAG}"
 
 tests_cleanup
-sgx_cleanup
+# sgx_cleanup
 export_test_env
 
 # run_sgx_simulator $SGX_WALLET_TAG
@@ -16,4 +16,3 @@ bash scripts/run_redis.sh
 
 python -m py.test tests/fair/dkg_test.py $@
 sgx_cleanup
-

--- a/scripts/run_fair_test.sh
+++ b/scripts/run_fair_test.sh
@@ -8,11 +8,8 @@ source $DIR/../helper-scripts/helper.sh
 : "${SGX_WALLET_TAG?Need to set SGX_WALLET_TAG}"
 
 tests_cleanup
-# sgx_cleanup
 export_test_env
 
-# run_sgx_simulator $SGX_WALLET_TAG
 bash scripts/run_redis.sh
 
 python -m py.test tests/fair/dkg_test.py $@
-sgx_cleanup

--- a/scripts/run_fair_test.sh
+++ b/scripts/run_fair_test.sh
@@ -11,7 +11,9 @@ tests_cleanup
 sgx_cleanup
 export_test_env
 
-run_sgx_simulator $SGX_WALLET_TAG
+# run_sgx_simulator $SGX_WALLET_TAG
 bash scripts/run_redis.sh
 
 python -m py.test tests/fair/dkg_test.py $@
+sgx_cleanup
+

--- a/scripts/run_sgxwallet.sh
+++ b/scripts/run_sgxwallet.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ea
+
+export DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $DIR/helper.sh
+source $DIR/../helper-scripts/helper.sh
+
+: "${SGX_WALLET_TAG?Need to set SGX_WALLET_TAG}"
+
+sgx_cleanup
+run_sgx_simulator $SGX_WALLET_TAG
+bash scripts/run_redis.sh


### PR DESCRIPTION
This pull request updates the committee configuration logic to include the staking contract address for each committee and ensures this information is propagated throughout the committee generation and serialization process. The changes improve both the data model and the output of committee-related functions.

**Committee Data Model Enhancements:**

* Added a new field `staking_contract_address` to the `CommitteeInfo` dataclass in `committee.py` and updated its `to_dict` method to include this field.
* Updated the `generate_committee_info` function to accept and pass the `staking_contract_address` when creating `CommitteeInfo` instances. [[1]](diffhunk://#diff-c51d9f6768da26472a50526ca0a60ff7b0a956d0f5a35200b44c954e7fc97d7cR130) [[2]](diffhunk://#diff-c51d9f6768da26472a50526ca0a60ff7b0a956d0f5a35200b44c954e7fc97d7cL141-R148)

**Committee Generation Logic:**

* Modified the committee generation logic in `generator.py` so that the committee dictionaries now include a `staking_contract_address` field (initialized with a checksummed zero address) for both the initial and chain start committees. [[1]](diffhunk://#diff-d0f369881abc6ac472c800ec474864d269529106fe01081c23fac7ec324fb305R127) [[2]](diffhunk://#diff-d0f369881abc6ac472c800ec474864d269529106fe01081c23fac7ec324fb305R139)

**Code Cleanliness and Imports:**

* Cleaned up and reordered imports in both `committee.py` and `generator.py` for clarity and consistency, including moving the import of `cast_manager_to_fair_node_id` and consolidating type imports. [[1]](diffhunk://#diff-c51d9f6768da26472a50526ca0a60ff7b0a956d0f5a35200b44c954e7fc97d7cR24-L25) [[2]](diffhunk://#diff-d0f369881abc6ac472c800ec474864d269529106fe01081c23fac7ec324fb305L28-L34) [[3]](diffhunk://#diff-d0f369881abc6ac472c800ec474864d269529106fe01081c23fac7ec324fb305L48-R47)

**Minor Refactoring:**

* Minor formatting and parameter alignment improvements in the `skale_node_to_fair_node_adapter` function for readability.