### PR TITLE
Fix passive node options

### DIFF
--- a/core/config/fair/committee.py
+++ b/core/config/fair/committee.py
@@ -74,7 +74,7 @@ class CommitteeInfo:
     def to_dict(self) -> dict:
         return {
             'blsKey': self.bls_key.to_dict(),
-            # 'stakingContractAddress': self.staking_contract_address, # todo: tmp fix
+            'stakingContractAddress': self.staking_contract_address,
             'group': [node.to_dict() for node in self.group],
         }
 

--- a/core/config/fair/fair_chain_node.py
+++ b/core/config/fair/fair_chain_node.py
@@ -45,7 +45,7 @@ class FairChainNodeInfo(NodeInfo):
             **parse_public_key_info(self.bls_public_key),
             **{
                 'owner': self.owner,
-                'rewardWalletAddress': self.reward_wallet_address,  # todo: fix for compatibility
+                'rewardWalletAddress': self.reward_wallet_address,
                 'schainIndex': self.committee_index,
                 'ip': self.ip,
                 'publicKey': self.public_key,

--- a/core/config/fair/fair_chain_node.py
+++ b/core/config/fair/fair_chain_node.py
@@ -45,7 +45,7 @@ class FairChainNodeInfo(NodeInfo):
             **parse_public_key_info(self.bls_public_key),
             **{
                 'owner': self.owner,
-                # 'rewardWalletAddress': self.reward_wallet_address, # todo: fix for compatibility
+                'rewardWalletAddress': self.reward_wallet_address,  # todo: fix for compatibility
                 'schainIndex': self.committee_index,
                 'ip': self.ip,
                 'publicKey': self.public_key,

--- a/core/config/fair/node_info.py
+++ b/core/config/fair/node_info.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass
 from skale.dataclasses.node_info import NodeInfo
 from skale.types.node import NodeId, Port
 
+from tools.configs import PASSIVE_NODE
+
 logger = logging.getLogger(__name__)
 
 
@@ -42,15 +44,14 @@ class FairCurrentNodeInfo(NodeInfo):
             **super().to_dict(),
             **{
                 'ecdsaKeyName': self.ecdsa_key_name,
-                # 'syncNode': not self.is_committee_node,
+                'syncNode': PASSIVE_NODE,
                 'info-acceptors': 1,
                 **self.static_node_info,
             },
         }
-        # todod: handle later
-        # if not self.is_committee_node:
-        #     node_info['archiveMode'] = self.archive
-        #     node_info['syncFromCatchup'] = self.catchup
+        if PASSIVE_NODE:
+            node_info['archiveMode'] = self.archive
+            node_info['syncFromCatchup'] = self.catchup
         return node_info
 
 


### PR DESCRIPTION
This pull request makes several updates to the serialization of configuration classes to ensure that all relevant fields are included in their dictionary representations, and introduces the use of the `PASSIVE_NODE` flag to control certain node behaviors. The changes primarily affect how configuration data is exported for nodes and committees.

**Serialization improvements:**

* Restored the inclusion of the `stakingContractAddress` field in the dictionary output of the `CommitteeInfo` class, ensuring this information is present when serializing committee data.
* Restored the inclusion of the `rewardWalletAddress` field in the dictionary output of the `FairChainNode` class, which is important for compatibility with other components expecting this field.

**Node behavior and configuration:**

* Imported the `PASSIVE_NODE` flag from `tools.configs` in `node_info.py` to control node synchronization behavior.
* Updated the `to_dict` method in `NodeInfo` to use the `PASSIVE_NODE` flag for the `syncNode` field, and to conditionally add `archiveMode` and `syncFromCatchup` fields when `PASSIVE_NODE` is enabled. This makes node configuration more flexible and explicit.