### PR TITLE
Add staking APIs, add copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,19 @@
+- always keep the changes minimal and purposeful
+- focus on fixing the exact problem or implementing the exact feature
+- keep the code simple, do not write defensive code
+- do not describe your changes in details after you made changes, focus on writing code
+- do not generate any documentation, the code should be self-explanatory
+- do not generate any in-line comments
+- for the new files, always add a license header, same format as in the existing files
+- no commented out code
+- no console logs in production code
+- no unused imports
+- no redundant code - move repeated logic into helper functions
+- use type hints to specify the expected types of function arguments and return values
+
+- check `ruff.toml` for formatting rules
+- always lint changes using `ruff check`
+- tests should be placed in `tests/` directory, follow the existing structure and code style
+- do not try to run tests
+
+- additional external context is located in context directory

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ package-lock.json
 scripts/.env
 
 static/
+context/
 
 __pycache__/
 *.pyc

--- a/fair_api.py
+++ b/fair_api.py
@@ -23,7 +23,7 @@ import os
 import time
 from http import HTTPStatus
 
-import werkzeug
+from werkzeug import exceptions as wz_exceptions
 from flask import Flask, g
 
 from core.node_config import NodeConfig
@@ -37,6 +37,7 @@ from web.routes.fair_node import fair_node_bp
 from web.routes.fair_node_passive import fair_node_passive_bp
 from web.routes.fair_chain import fair_chain_bp
 from web.routes.fair_wallet import wallet_bp
+from web.routes.fair_staking import fair_staking_bp
 from web.routes.ssl import ssl_bp
 
 REQ_ID_SIZE = 10
@@ -56,6 +57,7 @@ else:
     app.register_blueprint(fair_node_bp)
     app.register_blueprint(info_bp)
     app.register_blueprint(wallet_bp)
+    app.register_blueprint(fair_staking_bp)
 
 
 @app.before_request
@@ -83,7 +85,7 @@ def recursion_error_handler(e):
     )
 
 
-@app.errorhandler(werkzeug.exceptions.InternalServerError)
+@app.errorhandler(wz_exceptions.InternalServerError)
 def any_error_handler(e):
     original = getattr(e, 'original_exception', None)
     logger.exception('Request failed with error %s', original)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ websocket-client==1.8.0
 
 requests==2.32.4
 
-skale.py==7.4dev1
+skale.py==7.4dev2
 
 ima-predeployed==2.1.0b0
 etherbase-predeployed==1.1.0b3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 peewee==3.18.2
-Flask==3.1.1
+Flask==3.1.2
 Werkzeug==3.1.3
 gunicorn==23.0.0
 
@@ -10,7 +10,7 @@ websocket-client==1.8.0
 
 requests==2.32.4
 
-skale.py==7.3dev8
+skale.py==7.4dev1
 
 ima-predeployed==2.1.0b0
 etherbase-predeployed==1.1.0b3

--- a/web/routes/fair_staking.py
+++ b/web/routes/fair_staking.py
@@ -1,0 +1,227 @@
+#   -*- coding: utf-8 -*-
+#
+#   This file is part of SKALE Admin
+#
+#   Copyright (C) 2025 SKALE Labs
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+from http import HTTPStatus
+from typing import Iterable
+
+from flask import Blueprint, Response, g, request
+from skale.transactions.exceptions import TransactionError
+from skale.utils.web3_utils import to_checksum_address
+
+from core.node_config import NodeConfig
+from web.helper import (
+    construct_err_response,
+    construct_key_error_response,
+    construct_ok_response,
+    g_fair,
+    get_api_url,
+)
+
+logger = logging.getLogger(__name__)
+
+BLUEPRINT_NAME = 'fair-staking'
+fair_staking_bp = Blueprint(BLUEPRINT_NAME, __name__)
+
+
+def _get_body(required: Iterable[str] | None = None) -> tuple[dict, Response | None]:
+    body = request.get_json(silent=True) or {}
+    if required:
+        absent = [k for k in required if k not in body]
+        if absent:
+            return {}, construct_key_error_response(absent)
+    return body, None
+
+
+def _node_id_or_error(node_config: NodeConfig) -> tuple[int | None, Response | None]:
+    if not node_config.id:
+        return None, construct_err_response(
+            msg='Node is not registered', status_code=HTTPStatus.BAD_REQUEST
+        )
+    return node_config.id, None
+
+
+@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'add-allowed-receiver'), methods=['POST'])
+@g_fair
+def add_allowed_receiver() -> Response:
+    body, err = _get_body(['receiver'])
+    if err:
+        return err
+    try:
+        receiver = to_checksum_address(str(body['receiver']))
+    except Exception as e:
+        logger.exception('Invalid receiver address: %s', e)
+        return construct_err_response('Invalid receiver address')
+    try:
+        g.fair.staking.add_allowed_receiver(receiver)
+    except TransactionError as e:
+        logger.error('Error addAllowedReceiver: %s', e)
+        return construct_err_response(
+            msg=f'Error addAllowedReceiver: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+    return construct_ok_response()
+
+
+@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'remove-allowed-receiver'), methods=['POST'])
+@g_fair
+def remove_allowed_receiver() -> Response:
+    body, err = _get_body(['receiver'])
+    if err:
+        return err
+    try:
+        receiver = to_checksum_address(str(body['receiver']))
+    except Exception:
+        return construct_err_response('Invalid receiver address')
+    try:
+        g.fair.staking.remove_allowed_receiver(receiver)
+    except TransactionError as e:
+        logger.error('Error removeAllowedReceiver: %s', e)
+        return construct_err_response(
+            msg=f'Error removeAllowedReceiver: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+    return construct_ok_response()
+
+
+@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'send-all-fees'), methods=['POST'])
+@g_fair
+def send_all_fees() -> Response:
+    body, err = _get_body(['to'])
+    if err:
+        return err
+    try:
+        to = to_checksum_address(str(body['to']))
+    except Exception:
+        return construct_err_response('Invalid recipient address')
+    try:
+        g.fair.staking.send_all_fees(to)
+    except TransactionError as e:
+        logger.error('Error sendAllFees: %s', e)
+        return construct_err_response(
+            msg=f'Error sendAllFees: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+    return construct_ok_response()
+
+
+@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'claim-all-fees'), methods=['POST'])
+@g_fair
+def claim_all_fees() -> Response:
+    node_config: NodeConfig = g.config
+    node_id, err = _node_id_or_error(node_config)
+    if err:
+        return err
+    try:
+        g.fair.staking.claim_all_fees(node_id)
+    except TransactionError as e:
+        logger.error('Error claimAllFees: %s', e)
+        return construct_err_response(
+            msg=f'Error claimAllFees: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+    return construct_ok_response()
+
+
+@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'set-fee-rate'), methods=['POST'])
+@g_fair
+def set_fee_rate() -> Response:
+    body, err = _get_body(['feeRate'])
+    if err:
+        return err
+    try:
+        fee_rate = int(body['feeRate'])
+    except Exception:
+        return construct_err_response('Invalid feeRate')
+    try:
+        g.fair.staking.set_fee_rate(fee_rate)
+    except TransactionError as e:
+        logger.error('Error setFeeRate: %s', e)
+        return construct_err_response(
+            msg=f'Error setFeeRate: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+    return construct_ok_response()
+
+
+@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'claim-fees'), methods=['POST'])
+@g_fair
+def claim_fees() -> Response:
+    body, err = _get_body(['amount'])
+    if err:
+        return err
+    node_config: NodeConfig = g.config
+    node_id, node_err = _node_id_or_error(node_config)
+    if node_err:
+        return node_err
+    try:
+        amount = body['amount']
+        amount_wei = g.fair.web3.to_wei(amount, 'ether')
+    except Exception:
+        return construct_err_response('Invalid amount')
+    try:
+        g.fair.staking.claim_fees(node_id, int(amount_wei))
+    except TransactionError as e:
+        logger.error('Error claimFees: %s', e)
+        return construct_err_response(
+            msg=f'Error claimFees: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+    return construct_ok_response()
+
+
+@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'send-fees'), methods=['POST'])
+@g_fair
+def send_fees() -> Response:
+    body, err = _get_body(['to', 'amount'])
+    if err:
+        return err
+    try:
+        to = to_checksum_address(str(body['to']))
+    except Exception:
+        return construct_err_response('Invalid recipient address')
+    try:
+        amount = body['amount']
+        amount_wei = g.fair.web3.to_wei(amount, 'ether')
+    except Exception:
+        return construct_err_response('Invalid amount')
+    try:
+        g.fair.staking.send_fees(to, int(amount_wei))
+    except TransactionError as e:
+        logger.error('Error sendFees: %s', e)
+        return construct_err_response(
+            msg=f'Error sendFees: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+    return construct_ok_response()
+
+
+@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'get-earned-fee-amount'), methods=['POST'])
+@g_fair
+def get_earned_fee_amount() -> Response:
+    node_config: NodeConfig = g.config
+    node_id, err = _node_id_or_error(node_config)
+    if err:
+        return err
+    try:
+        amount_wei = g.fair.staking.get_earned_fee_amount(node_id)
+    except Exception as e:
+        logger.error('Error getEarnedFeeAmount: %s', e)
+        return construct_err_response(
+            msg=f'Error getEarnedFeeAmount: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+    return construct_ok_response(
+        {
+            'amount_wei': int(amount_wei),
+            'amount_ether': str(g.fair.web3.from_wei(int(amount_wei), 'ether')),
+        }
+    )

--- a/web/routes/fair_staking.py
+++ b/web/routes/fair_staking.py
@@ -57,9 +57,9 @@ def _node_id_or_error(node_config: NodeConfig) -> tuple[int | None, Response | N
     return node_config.id, None
 
 
-@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'add-allowed-receiver'), methods=['POST'])
+@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'add-receiver'), methods=['POST'])
 @g_fair
-def add_allowed_receiver() -> Response:
+def add_receiver() -> Response:
     body, err = _get_body(['receiver'])
     if err:
         return err
@@ -78,9 +78,9 @@ def add_allowed_receiver() -> Response:
     return construct_ok_response()
 
 
-@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'remove-allowed-receiver'), methods=['POST'])
+@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'remove-receiver'), methods=['POST'])
 @g_fair
-def remove_allowed_receiver() -> Response:
+def remove_receiver() -> Response:
     body, err = _get_body(['receiver'])
     if err:
         return err
@@ -94,26 +94,6 @@ def remove_allowed_receiver() -> Response:
         logger.error('Error removeAllowedReceiver: %s', e)
         return construct_err_response(
             msg=f'Error removeAllowedReceiver: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
-        )
-    return construct_ok_response()
-
-
-@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'send-all-fees'), methods=['POST'])
-@g_fair
-def send_all_fees() -> Response:
-    body, err = _get_body(['to'])
-    if err:
-        return err
-    try:
-        to = to_checksum_address(str(body['to']))
-    except Exception:
-        return construct_err_response('Invalid recipient address')
-    try:
-        g.fair.staking.send_all_fees(to)
-    except TransactionError as e:
-        logger.error('Error sendAllFees: %s', e)
-        return construct_err_response(
-            msg=f'Error sendAllFees: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
         )
     return construct_ok_response()
 
@@ -183,20 +163,21 @@ def claim_fees() -> Response:
 @fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'send-fees'), methods=['POST'])
 @g_fair
 def send_fees() -> Response:
-    body, err = _get_body(['to', 'amount'])
+    body, err = _get_body(['to'])
     if err:
         return err
     try:
         to = to_checksum_address(str(body['to']))
     except Exception:
         return construct_err_response('Invalid recipient address')
+    amount = body.get('amount')
+
     try:
-        amount = body['amount']
-        amount_wei = g.fair.web3.to_wei(amount, 'ether')
-    except Exception:
-        return construct_err_response('Invalid amount')
-    try:
-        g.fair.staking.send_fees(to, int(amount_wei))
+        if amount is None or amount == '':
+            g.fair.staking.send_all_fees(to)
+        else:
+            amount_wei = g.fair.web3.to_wei(amount, 'ether')
+            g.fair.staking.send_fees(to, int(amount_wei))
     except TransactionError as e:
         logger.error('Error sendFees: %s', e)
         return construct_err_response(

--- a/web/routes/fair_staking.py
+++ b/web/routes/fair_staking.py
@@ -98,23 +98,6 @@ def remove_receiver() -> Response:
     return construct_ok_response()
 
 
-@fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'claim-all-fees'), methods=['POST'])
-@g_fair
-def claim_all_fees() -> Response:
-    node_config: NodeConfig = g.config
-    node_id, err = _node_id_or_error(node_config)
-    if err:
-        return err
-    try:
-        g.fair.staking.claim_all_fees(node_id)
-    except TransactionError as e:
-        logger.error('Error claimAllFees: %s', e)
-        return construct_err_response(
-            msg=f'Error claimAllFees: {e}', status_code=HTTPStatus.INTERNAL_SERVER_ERROR
-        )
-    return construct_ok_response()
-
-
 @fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'set-fee-rate'), methods=['POST'])
 @g_fair
 def set_fee_rate() -> Response:
@@ -138,20 +121,20 @@ def set_fee_rate() -> Response:
 @fair_staking_bp.route(get_api_url(BLUEPRINT_NAME, 'claim-fees'), methods=['POST'])
 @g_fair
 def claim_fees() -> Response:
-    body, err = _get_body(['amount'])
+    body, err = _get_body()
     if err:
         return err
     node_config: NodeConfig = g.config
     node_id, node_err = _node_id_or_error(node_config)
     if node_err:
         return node_err
+    amount = body.get('amount')
     try:
-        amount = body['amount']
-        amount_wei = g.fair.web3.to_wei(amount, 'ether')
-    except Exception:
-        return construct_err_response('Invalid amount')
-    try:
-        g.fair.staking.claim_fees(node_id, int(amount_wei))
+        if amount is None or amount == '':
+            g.fair.staking.claim_all_fees(node_id)
+        else:
+            amount_wei = g.fair.web3.to_wei(amount, 'ether')
+            g.fair.staking.claim_fees(node_id, int(amount_wei))
     except TransactionError as e:
         logger.error('Error claimFees: %s', e)
         return construct_err_response(


### PR DESCRIPTION
This pull request introduces a new API blueprint for staking-related operations and makes several improvements to error handling and code organization. The main changes include adding the `fair_staking_bp` blueprint with multiple endpoints for staking actions, updating imports for clarity, and expanding the project's coding guidelines.

**New staking API endpoints and integration:**

* Added a new file `web/routes/fair_staking.py` implementing the `fair_staking_bp` blueprint, which provides endpoints for staking operations such as adding/removing allowed receivers, sending/claiming fees, setting fee rates, and querying earned fees. The implementation follows the project's conventions for error handling and input validation.
* Registered the new `fair_staking_bp` blueprint in the Flask app within `fair_api.py`, enabling the new staking endpoints. [[1]](diffhunk://#diff-f7f56ceb8202d24d8e8ca283ba5301ad819b3184ada77291c9b3e53bd4ca9dd9R40) [[2]](diffhunk://#diff-f7f56ceb8202d24d8e8ca283ba5301ad819b3184ada77291c9b3e53bd4ca9dd9R60)

**Code quality and maintainability improvements:**

* Updated the import of `werkzeug.exceptions` to use an alias (`wz_exceptions`) for clarity and replaced its usage throughout the error handling code. [[1]](diffhunk://#diff-f7f56ceb8202d24d8e8ca283ba5301ad819b3184ada77291c9b3e53bd4ca9dd9L26-R26) [[2]](diffhunk://#diff-f7f56ceb8202d24d8e8ca283ba5301ad819b3184ada77291c9b3e53bd4ca9dd9L86-R88)
* Expanded `.github/copilot-instructions.md` with more detailed coding standards, including requirements for minimal changes, code simplicity, license headers, linting, and test placement.