### PR TITLE
Fix scheduler on passive nodes, update fair APIs

### DIFF
--- a/core/monitor/action_base.py
+++ b/core/monitor/action_base.py
@@ -35,6 +35,7 @@ from core.redis.chain_record import ChainRecord
 from core.schains.cleaner import remove_schain_volume, remove_skaled_container
 from core.schains.exit_scheduler import ExitScheduleFileManager
 from core.types.chain import ChainName
+from tools.configs import PASSIVE_NODE
 from tools.configs.containers import SKALED_CONTAINER
 from tools.docker_utils import DockerUtils
 from tools.node_options import NodeOptions
@@ -155,7 +156,10 @@ class BaseSkaledActionManager(BaseActionManager):
         self.chain_record.set_failed_rpc_count(0)
         if type(self.chain_record) is ChainRecord:  # todo: remove after migration to ChainRecord
             self.chain_record.set_restart_ts(0)
-        initial_status = self.skaled_container(abort_on_exit=abort_on_exit)
+        initial_status = self.skaled_container(
+            abort_on_exit=abort_on_exit,
+            passive_node=PASSIVE_NODE,
+        )
         return initial_status
 
     @BaseActionManager.monitor_block

--- a/core/monitor/fair/healthcheck.py
+++ b/core/monitor/fair/healthcheck.py
@@ -74,7 +74,6 @@ def handle_healthcheck_job(
                 id=HEALTHCHECK_JOB_NAME,
                 name='fair healthcheck job',
             )
-            scheduler.start()
             logger.info('Healthcheck scheduler started - jobs will now execute')
         else:
             logger.info('Healthcheck job already exists in the scheduler, skipping')

--- a/core/monitor/fair/monitor_config.py
+++ b/core/monitor/fair/monitor_config.py
@@ -68,7 +68,7 @@ def run_config_pipeline(
     )
 
     chain_record = ChainRecord(chain_name)
-    logger.info('Chain record: %s', chain_record)
+    logger.info('Chain record: %s', chain_record.to_dict())
 
     logger.info('Initializing config checks')
     config_checks = FairConfigChecks(

--- a/core/monitor/schain/action_skaled.py
+++ b/core/monitor/schain/action_skaled.py
@@ -104,6 +104,7 @@ class SkaledActionManager(BaseSkaledActionManager):
         download_snapshot: bool = False,
         start_ts: Optional[int] = None,
         abort_on_exit: bool = True,
+        passive_node: bool = PASSIVE_NODE,
     ) -> bool:
         logger.info(
             'Starting skaled container watchman snapshot: %s, start_ts: %s',
@@ -120,7 +121,7 @@ class SkaledActionManager(BaseSkaledActionManager):
             start_ts=start_ts,
             abort_on_exit=abort_on_exit,
             dutils=self.dutils,
-            passive_node=PASSIVE_NODE,
+            passive_node=passive_node,
             historic_state=self.node_options.historic_state,
         )
         time.sleep(CONTAINER_POST_RUN_DELAY)

--- a/core/node.py
+++ b/core/node.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import platform
+import shutil
 import psutil
 import socket
 import time
@@ -28,6 +29,7 @@ from enum import Enum
 from typing import Dict, List, Optional, TypedDict
 
 import requests
+from requests.exceptions import RequestException, ConnectionError, Timeout, HTTPError
 
 from skale import SkaleManager
 from skale.schain_config.generator import get_nodes_for_schain
@@ -39,8 +41,15 @@ from skale.types.schain import SchainName
 from skale.types.node import NodeWithId
 
 from core.monitoring import update_monitoring_services
-from tools.configs import WATCHDOG_PORT, CHANGE_IP_DELAY, CHECK_REPORT_PATH, META_FILEPATH
-from tools.helper import read_json
+from tools.configs import (
+    PASSIVE_NODE,
+    WATCHDOG_PORT,
+    CHANGE_IP_DELAY,
+    CHECK_REPORT_PATH,
+    META_FILEPATH,
+)
+from tools.configs.schains import CHAIN_STATE_PATH
+from tools.helper import is_fair, read_json
 from tools.str_formatters import arguments_list_string
 from tools.wallet_utils import check_required_balance
 
@@ -290,13 +299,24 @@ def _get_node_status(node_info):
 
 def get_block_device_size() -> int:
     """Returns block device size in bytes"""
-    response = requests.get(DOCKER_LVMPY_BLOCK_SIZE_URL, json={'Name': None})
-    data = response.json()
-    if data['Err'] != '':
-        err = data['Err']
-        logger.info(f'Lvmpy returned an error {err}')
+    try:
+        if PASSIVE_NODE or is_fair():
+            total, _, _ = shutil.disk_usage(CHAIN_STATE_PATH)
+            return total
+    except (FileNotFoundError, PermissionError, OSError) as e:
+        print(f'Error getting block device size: {e}')
         return -1
-    return data['Size']
+    try:
+        response = requests.get(DOCKER_LVMPY_BLOCK_SIZE_URL, json={'Name': None}, timeout=10)
+        data = response.json()
+        if data['Err'] != '':
+            err = data['Err']
+            logger.error(f'Lvmpy returned an error {err}')
+            return -1
+        return data['Size']
+    except (RequestException, ConnectionError, Timeout, HTTPError) as e:
+        logger.exception(f'Error getting block device size: {e}')
+        return -1
 
 
 def get_node_hardware_info() -> dict:

--- a/core/node.py
+++ b/core/node.py
@@ -304,7 +304,7 @@ def get_block_device_size() -> int:
             total, _, _ = shutil.disk_usage(CHAIN_STATE_PATH)
             return total
     except (FileNotFoundError, PermissionError, OSError) as e:
-        print(f'Error getting block device size: {e}')
+        logger.exception(f'Error getting block device size: {e}')
         return -1
     try:
         response = requests.get(DOCKER_LVMPY_BLOCK_SIZE_URL, json={'Name': None}, timeout=10)

--- a/core/redis/chain_record.py
+++ b/core/redis/chain_record.py
@@ -145,7 +145,7 @@ class ChainRecord(FlatRedisRecord):
     def set_repair_ts(self, value: int | None) -> None:
         self._set_field('repair_ts', value)
 
-    def set_restart_ts(self, value: int | None) -> None:
+    def set_restart_ts(self, value: int) -> None:
         self._set_field('restart_ts', value)
 
     def reset_failed_counters(self) -> None:

--- a/fair.py
+++ b/fair.py
@@ -45,6 +45,7 @@ SLEEP_INTERVAL = 90
 
 def monitor(node_config: NodeConfig) -> None:
     scheduler = BackgroundScheduler()
+    scheduler.start()
     while True:
         try:
             start_tasks(node_config, scheduler=scheduler)
@@ -59,6 +60,7 @@ def update_chain_record() -> None:
     chain_name = get_fair_chain_name()
     chain_record = ChainRecord(chain_name)
     chain_record.set_first_run(True)
+    chain_record.set_restart_ts(0)
 
 
 def worker() -> None:

--- a/fair_api.py
+++ b/fair_api.py
@@ -50,12 +50,12 @@ app = Flask(__name__)
 
 app.register_blueprint(fair_chain_bp)
 app.register_blueprint(ssl_bp)
+app.register_blueprint(info_bp)
 
 if PASSIVE_NODE:
     app.register_blueprint(fair_node_passive_bp)
 else:
     app.register_blueprint(fair_node_bp)
-    app.register_blueprint(info_bp)
     app.register_blueprint(wallet_bp)
     app.register_blueprint(fair_staking_bp)
 

--- a/web/helper.py
+++ b/web/helper.py
@@ -106,7 +106,7 @@ def g_fair(func):
     return wrapper
 
 
-def g_fair_passive(func):
+def g_fair_no_wallet(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         g.fair = init_fair_manager()

--- a/web/routes/fair_chain.py
+++ b/web/routes/fair_chain.py
@@ -32,7 +32,12 @@ from core.node_config import NodeConfig
 from core.redis.chain_record import ChainRecord
 from tools.configs import PASSIVE_NODE
 from tools.docker_utils import DockerUtils
-from web.helper import construct_err_response, construct_ok_response, g_fair, get_api_url
+from web.helper import (
+    construct_err_response,
+    construct_ok_response,
+    g_fair_passive,
+    get_api_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +67,7 @@ def record():
 
 
 @fair_chain_bp.route(get_api_url(BLUEPRINT_NAME, 'checks'), methods=['GET'])
-@g_fair
+@g_fair_passive
 def checks():
     logger.debug(request)
     fair: FairManager = g.fair

--- a/web/routes/fair_chain.py
+++ b/web/routes/fair_chain.py
@@ -35,7 +35,7 @@ from tools.docker_utils import DockerUtils
 from web.helper import (
     construct_err_response,
     construct_ok_response,
-    g_fair_passive,
+    g_fair_no_wallet,
     get_api_url,
 )
 
@@ -67,7 +67,7 @@ def record():
 
 
 @fair_chain_bp.route(get_api_url(BLUEPRINT_NAME, 'checks'), methods=['GET'])
-@g_fair_passive
+@g_fair_no_wallet
 def checks():
     logger.debug(request)
     fair: FairManager = g.fair

--- a/web/routes/fair_node_passive.py
+++ b/web/routes/fair_node_passive.py
@@ -27,7 +27,7 @@ from core.node_config import NodeConfig
 from web.helper import (
     construct_err_response,
     construct_ok_response,
-    g_fair_passive,
+    g_fair_no_wallet,
     get_api_url,
 )
 
@@ -38,7 +38,7 @@ fair_node_passive_bp = Blueprint(BLUEPRINT_NAME, __name__)
 
 
 @fair_node_passive_bp.route(get_api_url(BLUEPRINT_NAME, 'info'), methods=['GET'])
-@g_fair_passive
+@g_fair_no_wallet
 def info():
     logger.debug(request)
     node_config: NodeConfig = g.config
@@ -52,7 +52,7 @@ def info():
 
 
 @fair_node_passive_bp.route(get_api_url(BLUEPRINT_NAME, 'setup'), methods=['POST'])
-@g_fair_passive
+@g_fair_no_wallet
 def setup():
     logger.debug(request)
     if not request.json:


### PR DESCRIPTION
This pull request contains several improvements and bug fixes across the monitoring, scheduling, and API registration logic. The main focus is on correcting scheduler initialization, improving logging, making the chain record restart timestamp handling more robust, and ensuring API blueprints are registered appropriately.

Scheduler and Monitoring Logic:

* Moved the `scheduler.start()` call from the healthcheck job handler to the main `monitor` function to ensure the scheduler is started only once, preventing potential duplicate starts. [[1]](diffhunk://#diff-8a49e327b6ec59c342a7cfc98be616962f5f4e857f98e9ef8bde9a301a634822R48) [[2]](diffhunk://#diff-16322cdfa0be105dfae6bcc182df444d14ceea8bcfe845eae3639028205b2477L77)

Chain Record Handling:

* Changed `set_restart_ts` in `ChainRecord` to require a non-optional integer, ensuring the restart timestamp is always set explicitly.
* Explicitly sets `restart_ts` to 0 during chain record initialization in `update_chain_record` to provide a clear starting state.

Logging Improvements:

* Updated logging in the config pipeline to output the dictionary representation of `chain_record` for clearer log messages.

API Blueprint Registration:

* Adjusted the order and conditions for registering the `info_bp` blueprint in `fair_api.py` to ensure it is always registered, regardless of node mode.