### PR TITLE
Fix nginx container name after renaming

### DIFF
--- a/tools/configs/nginx.py
+++ b/tools/configs/nginx.py
@@ -2,6 +2,6 @@ import os
 
 from tools.configs import CONFIG_FOLDER, NODE_DATA_PATH
 
-NGINX_CONTAINER_NAME = 'skale_nginx'
+NGINX_CONTAINER_NAME = 'sk_nginx'
 NGINX_TEMPLATE_FILEPATH = os.path.join(CONFIG_FOLDER, 'nginx.conf.j2')
 NGINX_CONFIG_FILEPATH = os.path.join(NODE_DATA_PATH, 'nginx.conf')


### PR DESCRIPTION
This pull request makes a small update to the `tools/configs/nginx.py` file by renaming the `NGINX_CONTAINER_NAME` constant to use a shorter name.

* Changed `NGINX_CONTAINER_NAME` from `'skale_nginx'` to `'sk_nginx'` for consistency or brevity.