### PR TITLE
Update fair manager, add self staking for active fair node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: self-hosted
     env:
       ENDPOINT: http://127.0.0.1:1234
-      FAIR_TAG: "0.0.1-develop.50"
+      FAIR_TAG: "0.0.1-develop.71"
       SKALED_TAG: 4.1.0-develop.24-mirage
 
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ websocket-client==1.8.0
 
 requests==2.32.4
 
-skale.py==7.4dev3
+skale.py==7.4dev4
 
 ima-predeployed==2.1.0b0
 etherbase-predeployed==1.1.0b3

--- a/tests/fair/dkg_test.py
+++ b/tests/fair/dkg_test.py
@@ -264,9 +264,7 @@ class TestDKGFair:
     def new_wallet(self, fair):
         wallet = generate_sgx_wallets(fair, 1)[0]
         print('Address', fair.wallet.address, fair.web3.eth.get_balance(fair.wallet.address))
-        send_eth(
-            web3=fair.web3, wallet=fair.wallet, receiver_address=wallet.address, amount=0.1
-        )
+        send_eth(web3=fair.web3, wallet=fair.wallet, receiver_address=wallet.address, amount=0.1)
         return wallet
 
     @pytest.fixture
@@ -276,7 +274,8 @@ class TestDKGFair:
     @pytest.fixture
     def fair_new_node(self, fair, new_fair_instance):
         ip, _, port, _ = generate_random_node_data()
-        new_fair_instance.nodes.register_active(ip, port)
+        self_stake_requirement = new_fair_instance.staking.self_stake_requirement()
+        new_fair_instance.nodes.register_active(ip, port, value=self_stake_requirement)
         return new_fair_instance.nodes.get_by_address(new_fair_instance.wallet.address)
 
     @pytest.fixture

--- a/web/routes/fair_node.py
+++ b/web/routes/fair_node.py
@@ -59,7 +59,8 @@ def register():
 
     fair: FairManager = g.fair
     try:
-        fair.nodes.register_active(ip, port)
+        self_stake_requirement = fair.staking.self_stake_requirement()
+        fair.nodes.register_active(ip, port, value=self_stake_requirement)
     except TransactionError as e:
         logger.error(f'Error registering node: {e}')
         return construct_err_response(


### PR DESCRIPTION
This pull request updates the node registration logic to ensure that nodes are registered with the required stake value, aligning both the backend and test code with current staking requirements. Additionally, it updates a dependency tag in the test workflow configuration.

**Node registration and staking requirement updates:**

* In `web/routes/fair_node.py`, node registration now includes the `self_stake_requirement` value, ensuring nodes meet staking requirements at registration.
* In `tests/fair/dkg_test.py`, the fixture for new nodes (`fair_new_node`) also passes the `self_stake_requirement` when registering a node, matching the backend change.

**Workflow and formatting updates:**

* The `FAIR_TAG` environment variable in `.github/workflows/test.yml` is updated to a newer version, ensuring tests run against the latest contract image.
* Minor formatting improvement in `tests/fair/dkg_test.py` for the `send_eth` function call for consistency.