### PR TITLE
1274 Remove inf from maxConsensusStorageBytes for indexer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Ensure PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Install python dependencies
         run: |
           source ../.venv/bin/activate

--- a/core/schains/config/schain_info.py
+++ b/core/schains/config/schain_info.py
@@ -21,13 +21,13 @@ from dataclasses import dataclass
 
 from core.schains.limits import get_allocation_type_name, get_schain_limit, get_schain_type
 from core.schains.types import MetricType
-
-from tools.configs.schains import MAX_CONSENSUS_STORAGE_INF_VALUE, MAX_HISTORIC_STATE_DB_SIZE
+from tools.configs.schains import MAX_HISTORIC_STATE_DB_SIZE
 
 
 @dataclass
 class SChainInfo:
     """Dataclass that represents sChain key of the skaleConfig section"""
+
     schain_id: int
     name: str
     block_author: str
@@ -62,7 +62,7 @@ class SChainInfo:
             'nodeGroups': self.node_groups,
             'multiTransactionMode': self.multitransaction_mode,
             'nodes': self.nodes,
-            **self.static_schain_info
+            **self.static_schain_info,
         }
         if self.max_historic_state_db_size:
             data.update({'maxHistoricStateDbSize': self.max_historic_state_db_size})
@@ -77,13 +77,12 @@ def generate_schain_info(
     node_groups: dict,
     nodes: dict,
     sync_node: bool,
-    archive: bool
+    archive: bool,
 ) -> SChainInfo:
     schain_type = get_schain_type(schain.part_of_node)
     allocation_type_name = get_allocation_type_name(schain.options.allocation_type)
     volume_limits = get_schain_limit(schain_type, MetricType.volume_limits)[allocation_type_name]
     if sync_node and archive:
-        volume_limits['max_consensus_storage_bytes'] = MAX_CONSENSUS_STORAGE_INF_VALUE
         volume_limits['max_historic_state_db_size'] = MAX_HISTORIC_STATE_DB_SIZE
     leveldb_limits = get_schain_limit(schain_type, MetricType.leveldb_limits)[allocation_type_name]
     contract_storage_limit = leveldb_limits['contract_storage']
@@ -99,5 +98,5 @@ def generate_schain_info(
         nodes=nodes,
         multitransaction_mode=schain.options.multitransaction_mode,
         static_schain_info=static_schain_info,
-        **volume_limits
+        **volume_limits,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,6 @@ pyOpenSSL==23.1.1
 python-dateutil==2.8.2
 python-telegram-bot==12.8
 sh==1.14.1
+
+# for predeployeds
+setuptools==80.9.0

--- a/tests/schains/config/generator_test.py
+++ b/tests/schains/config/generator_test.py
@@ -606,7 +606,6 @@ def test_generate_sync_node_config_archive_catchup(
 
     assert not config['skaleConfig']['nodeInfo'].get('syncFromCatchup')
     assert not config['skaleConfig']['nodeInfo'].get('archiveMode')
-    assert config['skaleConfig']['sChain'].get('maxConsensusStorageBytes') < 1000000000000000000
 
     schain_config = generate_schain_config(
         schain=get_schain_struct_no_originator(),
@@ -629,7 +628,6 @@ def test_generate_sync_node_config_archive_catchup(
 
     assert config['skaleConfig']['nodeInfo'].get('syncFromCatchup')
     assert config['skaleConfig']['nodeInfo'].get('archiveMode') is False
-    assert config['skaleConfig']['sChain'].get('maxConsensusStorageBytes') < 1000000000000000000
 
     schain_config = generate_schain_config(
         schain=get_schain_struct_no_originator(),
@@ -652,7 +650,6 @@ def test_generate_sync_node_config_archive_catchup(
 
     assert config['skaleConfig']['nodeInfo'].get('syncFromCatchup') is None
     assert config['skaleConfig']['nodeInfo'].get('archiveMode') is None
-    assert config['skaleConfig']['sChain'].get('maxConsensusStorageBytes') < 1000000000000000000
 
     schain_config = generate_schain_config(
         schain=get_schain_struct_no_originator(),
@@ -675,7 +672,6 @@ def test_generate_sync_node_config_archive_catchup(
 
     assert config['skaleConfig']['nodeInfo'].get('syncFromCatchup')
     assert config['skaleConfig']['nodeInfo'].get('archiveMode')
-    assert config['skaleConfig']['sChain'].get('maxConsensusStorageBytes') == 1000000000000000000
 
 
 def test_generate_sync_node_config_static_accounts(

--- a/tools/configs/schains.py
+++ b/tools/configs/schains.py
@@ -18,12 +18,8 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
-from tools.configs import (
-    CONFIG_FOLDER,
-    NODE_DATA_PATH,
-    NODE_DATA_PATH_HOST,
-    SKALE_LIB_PATH
-)
+
+from tools.configs import CONFIG_FOLDER, NODE_DATA_PATH, NODE_DATA_PATH_HOST, SKALE_LIB_PATH
 
 SCHAINS_DIR_NAME = 'schains'
 SCHAINS_DIR_PATH = os.path.join(NODE_DATA_PATH, SCHAINS_DIR_NAME)
@@ -53,7 +49,6 @@ SCHAIN_STATIC_PATH = os.path.join(SKALE_LIB_PATH, 'filestorage')
 DEFAULT_RPC_CHECK_TIMEOUT = 30
 RPC_CHECK_TIMEOUT_STEP = 10
 
-MAX_CONSENSUS_STORAGE_INF_VALUE = 1000000000000000000
 MAX_HISTORIC_STATE_DB_SIZE = 2530799910
 
 DKG_TIMEOUT_COEFFICIENT = 2.2


### PR DESCRIPTION
This pull request makes minor cleanup and refactoring changes to configuration handling for sChain information. The main focus is on removing the unused `MAX_CONSENSUS_STORAGE_INF_VALUE` constant and simplifying import statements, as well as making small stylistic improvements to dictionary construction.

Configuration cleanup and refactoring:

* Removed the unused `MAX_CONSENSUS_STORAGE_INF_VALUE` constant from `tools/configs/schains.py` and its usage in `generate_schain_info` in `core/schains/config/schain_info.py`, streamlining the configuration logic. [[1]](diffhunk://#diff-7aa8454def28c8a6654f68ab443c0aee4b6c56214fd76d2d124eeb5a28716e17L56) [[2]](diffhunk://#diff-94de871301e5f0954d45cf9efe18bcbb972fe2fa9ed9e5c1af40f15ade7cc230L24-R30) [[3]](diffhunk://#diff-94de871301e5f0954d45cf9efe18bcbb972fe2fa9ed9e5c1af40f15ade7cc230L80-L86)
* Simplified import statements in `tools/configs/schains.py` by combining multiple imports into a single line for better readability.
* Added trailing commas to dictionary unpacking in `core/schains/config/schain_info.py` to improve code style and maintain consistency. [[1]](diffhunk://#diff-94de871301e5f0954d45cf9efe18bcbb972fe2fa9ed9e5c1af40f15ade7cc230L65-R65) [[2]](diffhunk://#diff-94de871301e5f0954d45cf9efe18bcbb972fe2fa9ed9e5c1af40f15ade7cc230L102-R101)