### PR TITLE
Update skale.py version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "docker==7.1.0",
     "websocket-client==1.8.0",
     "requests==2.32.5",
-    "skale.py==7.5dev1",
+    "skale.py==7.6dev2",
     "ima-predeployed==2.1.0b0",
     "etherbase-predeployed==1.1.0b3",
     "marionette-predeployed==2.0.0b2",


### PR DESCRIPTION
This pull request makes a minor update to the `pyproject.toml` dependencies, upgrading the `skale.py` package from version `7.5dev1` to `7.6dev2`.