### PR TITLE
Fix FAIR historic config

### DIFF
--- a/core/config/fair/generator.py
+++ b/core/config/fair/generator.py
@@ -35,7 +35,7 @@ from skale.utils.web3_utils import public_key_to_address, to_checksum_address
 from core.config.base import FairConfig, SChainBaseConfig
 from core.config.fair.committee import generate_committee_info
 from core.config.fair.node_info import FairCurrentNodeInfo, generate_fair_current_node_info
-from core.config.fair.schain_info import FairChainInfo
+from core.config.fair.schain_info import FairChainInfo, generate_schain_info
 from core.config.precompiled import get_precompiled_contracts_fair
 from core.config.schain.static_params import (
     get_static_chain_id_fair,
@@ -185,11 +185,11 @@ def generate_fair_config(
         committee_info_from_manager=committee_info_from_manager,
         node_id=node.id,
     )
-
-    schain_info = FairChainInfo(
+    schain_info = generate_schain_info(
         schain_id=chain_id_int,
         node_groups=node_groups,
         nodes=committee_info,
+        archive=archive,
         static_schain_info=static_schain_info,
     )
 

--- a/core/config/fair/schain_info.py
+++ b/core/config/fair/schain_info.py
@@ -58,17 +58,13 @@ def generate_schain_info(
     schain_id: int,
     static_schain_info: dict,
     node_groups: dict,
-    nodes: list,
-    passive_node: bool,
+    nodes: dict[int, CommitteeInfo],
     archive: bool,
 ) -> FairChainInfo:
-    # TODOd: fix override from config
-    if passive_node and archive:
-        # max_consensus_storage_bytes = MAX_CONSENSUS_STORAGE_INF_VALUE
+    if archive:
         max_historic_state_db_size = MAX_HISTORIC_STATE_DB_SIZE
     else:
         max_historic_state_db_size = None
-        # max_consensus_storage_bytes = 10  # todo: from config
 
     return FairChainInfo(
         schain_id=schain_id,


### PR DESCRIPTION
This pull request refactors how `FairChainInfo` instances are created within the fair configuration generator, shifting from direct instantiation to using the dedicated `generate_schain_info` function. This change helps centralize and standardize the logic for generating chain info, and also streamlines the arguments passed, notably removing the unused `passive_node` parameter and improving type consistency.

Refactoring and code consistency:

* Updated the import in `core/config/fair/generator.py` to bring in `generate_schain_info` alongside `FairChainInfo`, preparing for its use in generating chain info.
* Replaced direct instantiation of `FairChainInfo` in `generate_fair_config` with a call to `generate_schain_info`, passing the correct arguments and ensuring the `archive` flag is included.
* Refactored the signature of `generate_schain_info` in `core/config/fair/schain_info.py` to remove the unused `passive_node` parameter, clarify the type of `nodes` (now `dict[int, CommitteeInfo]`), and simplify the logic for setting `max_historic_state_db_size` based solely on the `archive` flag.