### PR TITLE
Update skale.py version - alive gas limit fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "docker==7.1.0",
     "websocket-client==1.8.0",
     "requests==2.32.5",
-    "skale.py==7.6dev2",
+    "skale.py==7.6dev4",
     "ima-predeployed==2.1.0b0",
     "etherbase-predeployed==1.1.0b3",
     "marionette-predeployed==2.0.0b2",


### PR DESCRIPTION
This pull request updates the version of the `skale.py` dependency in the `pyproject.toml` file to ensure compatibility with the latest features and bug fixes.

* Dependency update:
  * Upgraded `skale.py` from version `7.6dev2` to `7.6dev4` in `pyproject.toml`.