### PR TITLE
Add ability to run BITE version of skaled

### DIFF
--- a/core/chain/runner.py
+++ b/core/chain/runner.py
@@ -33,6 +33,7 @@ from core.schains.limits import get_ima_limit, get_schain_limit, get_schain_type
 from core.schains.types import ContainerType, MetricType
 from core.types.chain import ChainName
 from tools.configs import (
+    BITE,
     NODE_DATA_PATH_HOST,
     SCHAIN_CONFIG_DIR_SKALED,
     SCHAIN_NODE_DATA_PATH,
@@ -84,6 +85,8 @@ def get_image_name(image_type: str, new: bool = False, historic_state: bool = Fa
     if image_type == SKALED_CONTAINER:
         if is_fair():
             image_name += FAIR_IMAGE_SUFFIX
+        if BITE:
+            image_name += '-bite'
         if historic_state:
             image_name += HISTORIC_STATE_IMAGE_POSTFIX
     return image_name

--- a/tools/configs/__init__.py
+++ b/tools/configs/__init__.py
@@ -49,6 +49,9 @@ BACKUP_RUN = os.getenv('BACKUP_RUN', False)
 NODE_CONFIG_LOCK_PATH = os.getenv('NODE_CONFIG_LOCK_PATH')
 if not NODE_CONFIG_LOCK_PATH:
     NODE_CONFIG_LOCK_PATH = os.path.join(NODE_DATA_PATH, 'node_config.lock')
+
+BITE = os.getenv('BITE') == 'True'
+
 INIT_LOCK_PATH = os.getenv('INIT_LOCK_PATH')
 if not INIT_LOCK_PATH:
     INIT_LOCK_PATH = os.path.join(NODE_DATA_PATH, 'init.lock')

--- a/tools/configs/__init__.py
+++ b/tools/configs/__init__.py
@@ -2,7 +2,7 @@ import os
 
 DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 
-RUNNING_ON_HOST = os.getenv('RUNNING_ON_HOST', False)
+RUNNING_ON_HOST = os.getenv('RUNNING_ON_HOST') == 'True'
 SKALE_DIR_HOST = os.getenv('SKALE_DIR_HOST')
 NODE_DATA_PATH_HOST = os.path.join(SKALE_DIR_HOST, 'node_data')
 


### PR DESCRIPTION
This pull request introduces a new environment variable, `BITE`, and updates how certain environment variables are interpreted. The main purpose is to enable conditional logic for container image naming and configuration based on the presence of the `BITE` flag.

Configuration and environment variable handling:

* Changed the evaluation of `RUNNING_ON_HOST` to explicitly check if the environment variable is set to `'True'`, improving reliability of boolean environment values (`tools/configs/__init__.py`).
* Added a new environment variable, `BITE`, which is set to `True` if the corresponding environment variable is `'True'` (`tools/configs/__init__.py`).

Container image naming logic:

* Updated the `get_image_name` function to append `-bite` to the image name if the `BITE` flag is enabled, allowing for differentiated container images (`core/chain/runner.py`).
* Imported the new `BITE` variable into the container runner logic to support the above change (`core/chain/runner.py`).