### PR TITLE
Update schain config generation

### DIFF
--- a/core/config/schain/generator.py
+++ b/core/config/schain/generator.py
@@ -161,7 +161,13 @@ def generate_schain_config(
 
     base_config = SChainBaseConfig(BASE_SCHAIN_CONFIG_FILEPATH)
 
-    dynamic_params = {'chainID': get_chain_id(schain.name)}
+    dynamic_params = {
+        'chainID': get_chain_id(schain.name),
+        'dynamicPricingMinPrice': schain.options.min_gas_price,
+        'dynamicPricingStartPrice': schain.options.min_gas_price,
+        'dynamicPricingMaxPrice': schain.options.max_gas_price,
+        'externalGasDifficulty': schain.options.external_gas_difficulty,
+    }
 
     legacy_groups = static_groups(schain.name)
     logger.debug('Legacy node groups: %s', legacy_groups)

--- a/core/config/schain/generator.py
+++ b/core/config/schain/generator.py
@@ -163,9 +163,6 @@ def generate_schain_config(
 
     dynamic_params = {
         'chainID': get_chain_id(schain.name),
-        'dynamicPricingMinPrice': schain.options.min_gas_price,
-        'dynamicPricingStartPrice': schain.options.min_gas_price,
-        'dynamicPricingMaxPrice': schain.options.max_gas_price,
         'externalGasDifficulty': schain.options.external_gas_difficulty,
     }
 

--- a/core/config/schain/node_info.py
+++ b/core/config/schain/node_info.py
@@ -44,6 +44,9 @@ class CurrentNodeInfo(NodeInfo):
     catchup: bool
     archive: bool
 
+    min_gas_price: str | None = None
+    max_gas_price: str | None = None
+
     def to_dict(self):
         """Returns camel-case representation of the CurrentNodeInfo object"""
         node_info = {
@@ -53,6 +56,9 @@ class CurrentNodeInfo(NodeInfo):
                 'wallets': self.wallets,
                 'syncNode': self.passive_node,
                 'info-acceptors': 1,
+                'dynamicPricingMinPrice': self.min_gas_price,
+                'dynamicPricingStartPrice': self.min_gas_price,
+                'dynamicPricingMaxPrice': self.max_gas_price,
                 **self.static_node_info,
             },
         }
@@ -93,6 +99,8 @@ def generate_current_node_info(
         archive=archive,
         catchup=catchup,
         static_node_info=static_node_info,
+        min_gas_price=schain.options.min_gas_price,
+        max_gas_price=schain.options.max_gas_price,
     )
 
 

--- a/core/config/schain/node_info.py
+++ b/core/config/schain/node_info.py
@@ -56,12 +56,18 @@ class CurrentNodeInfo(NodeInfo):
                 'wallets': self.wallets,
                 'syncNode': self.passive_node,
                 'info-acceptors': 1,
-                'dynamicPricingMinPrice': self.min_gas_price,
-                'dynamicPricingStartPrice': self.min_gas_price,
-                'dynamicPricingMaxPrice': self.max_gas_price,
                 **self.static_node_info,
             },
         }
+
+        if self.min_gas_price is not None:
+            min_price = int(self.min_gas_price, 0)
+            node_info['dynamicPricingMinPrice'] = min_price
+            node_info['dynamicPricingStartPrice'] = min_price
+
+        if self.max_gas_price is not None:
+            node_info['dynamicPricingMaxPrice'] = int(self.max_gas_price, 0)
+
         if self.passive_node:
             node_info['archiveMode'] = self.archive
             node_info['syncFromCatchup'] = self.catchup

--- a/core/config/schain/node_info.py
+++ b/core/config/schain/node_info.py
@@ -44,8 +44,8 @@ class CurrentNodeInfo(NodeInfo):
     catchup: bool
     archive: bool
 
-    min_gas_price: str | None = None
-    max_gas_price: str | None = None
+    min_gas_price: int | None = None
+    max_gas_price: int | None = None
 
     def to_dict(self):
         """Returns camel-case representation of the CurrentNodeInfo object"""
@@ -61,12 +61,12 @@ class CurrentNodeInfo(NodeInfo):
         }
 
         if self.min_gas_price is not None:
-            min_price = int(self.min_gas_price, 0)
+            min_price = self.min_gas_price
             node_info['dynamicPricingMinPrice'] = min_price
             node_info['dynamicPricingStartPrice'] = min_price
 
         if self.max_gas_price is not None:
-            node_info['dynamicPricingMaxPrice'] = int(self.max_gas_price, 0)
+            node_info['dynamicPricingMaxPrice'] = self.max_gas_price
 
         if self.passive_node:
             node_info['archiveMode'] = self.archive

--- a/core/manager_cache_helper.py
+++ b/core/manager_cache_helper.py
@@ -20,7 +20,7 @@
 import logging
 from typing import Any
 
-from eth_typing import ChecksumAddress
+from eth_typing import ChecksumAddress, HexStr
 from skale import SkaleManager
 from skale.dataclasses.schain_options import AllocationType, SchainOptions
 from skale.types.node import NodeId, NodeWithChangeIp
@@ -89,6 +89,9 @@ def schain_structure_from_dict(d: dict[str, Any]) -> SchainStructure:
             multitransaction_mode=bool(opt['multitransaction_mode']),
             threshold_encryption=bool(opt['threshold_encryption']),
             allocation_type=AllocationType(opt['allocation_type']),
+            external_gas_difficulty=HexStr(opt.get('external_gas_difficulty', '0x01')),
+            min_gas_price=HexStr(opt.get('min_gas_price')) if opt.get('min_gas_price') else None,
+            max_gas_price=HexStr(opt.get('max_gas_price')) if opt.get('max_gas_price') else None,
         ),
         active=bool(d['active']),
     )

--- a/core/manager_cache_helper.py
+++ b/core/manager_cache_helper.py
@@ -90,8 +90,8 @@ def schain_structure_from_dict(d: dict[str, Any]) -> SchainStructure:
             threshold_encryption=bool(opt['threshold_encryption']),
             allocation_type=AllocationType(opt['allocation_type']),
             external_gas_difficulty=HexStr(opt.get('external_gas_difficulty', '0x01')),
-            min_gas_price=HexStr(opt.get('min_gas_price')) if opt.get('min_gas_price') else None,
-            max_gas_price=HexStr(opt.get('max_gas_price')) if opt.get('max_gas_price') else None,
+            min_gas_price=opt.get('min_gas_price'),
+            max_gas_price=opt.get('max_gas_price'),
         ),
         active=bool(d['active']),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "docker==7.1.0",
     "websocket-client==1.8.0",
     "requests==2.32.5",
-    "skale.py==7.11dev4",
+    "skale.py==7.11dev5",
     "ima-predeployed==2.3.0b3",
     "etherbase-predeployed==1.1.0b3",
     "marionette-predeployed==2.0.0b2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "docker==7.1.0",
     "websocket-client==1.8.0",
     "requests==2.32.5",
-    "skale.py==7.11dev5",
+    "skale.py==7.11dev6",
     "ima-predeployed==2.3.0b3",
     "etherbase-predeployed==1.1.0b3",
     "marionette-predeployed==2.0.0b2",

--- a/tests/schains/config/generator_test.py
+++ b/tests/schains/config/generator_test.py
@@ -584,6 +584,43 @@ def test_generate_schain_config_with_skale_gen2(
     assert schain_config_dict['skaleConfig']['sChain']['schainID'] == get_schain_id(schain_name)
 
 
+def test_generate_schain_config_with_dynamic_pricing(
+    skale_ima: SkaleIma,
+):
+    node_id, generation, rotation_id = NodeId(1), 2, 0
+    ecdsa_key_name = 'test'
+    min_price_hex = HexStr('0x123')
+    max_price_hex = HexStr('0x456')
+    min_price_int = int(min_price_hex, 0)
+    max_price_int = int(max_price_hex, 0)
+
+    schain = get_schain_struct(SCHAIN_NAME)
+    schain.options.min_gas_price = min_price_hex
+    schain.options.max_gas_price = max_price_hex
+    contracts_addresses = get_ima_contracts_addresses(skale_ima)
+
+    schain_config = generate_schain_config(
+        schain=schain,
+        node=TEST_NODE,
+        node_id=node_id,
+        ecdsa_key_name=ecdsa_key_name,
+        rotation_id=rotation_id,
+        schain_nodes_with_schain_hashes=get_schain_nodes_with_schain_hashes(SCHAIN_NAME),
+        node_groups=EMPTY_NODE_GROUPS,
+        generation=generation,
+        is_owner_contract=False,
+        common_bls_public_keys=COMMON_BLS_PUBLIC_KEY,
+        schain_base_port=10000,
+        mainnet_ima_addresses=contracts_addresses,
+    )
+    config = schain_config.to_dict()
+
+    node_info = config['skaleConfig']['nodeInfo']
+    assert node_info['dynamicPricingMinPrice'] == min_price_int
+    assert node_info['dynamicPricingStartPrice'] == min_price_int
+    assert node_info['dynamicPricingMaxPrice'] == max_price_int
+
+
 def test_get_schain_originator():
     originator = get_schain_originator(get_schain_struct_no_originator())
     assert originator == TEST_MAINNET_OWNER_ADDRESS

--- a/tests/schains/config/generator_test.py
+++ b/tests/schains/config/generator_test.py
@@ -586,6 +586,7 @@ def test_generate_schain_config_with_skale_gen2(
 
 def test_generate_schain_config_with_dynamic_pricing(
     skale_ima: SkaleIma,
+    schain_secret_key_file_default_chain,
 ):
     node_id, generation, rotation_id = NodeId(1), 2, 0
     ecdsa_key_name = 'test'

--- a/tests/schains/config/generator_test.py
+++ b/tests/schains/config/generator_test.py
@@ -590,14 +590,12 @@ def test_generate_schain_config_with_dynamic_pricing(
 ):
     node_id, generation, rotation_id = NodeId(1), 2, 0
     ecdsa_key_name = 'test'
-    min_price_hex = HexStr('0x123')
-    max_price_hex = HexStr('0x456')
-    min_price_int = int(min_price_hex, 0)
-    max_price_int = int(max_price_hex, 0)
+    min_price_int = 100000
+    max_price_int = 200000
 
     schain = get_schain_struct(SCHAIN_NAME)
-    schain.options.min_gas_price = min_price_hex
-    schain.options.max_gas_price = max_price_hex
+    schain.options.min_gas_price = min_price_int
+    schain.options.max_gas_price = max_price_int
     contracts_addresses = get_ima_contracts_addresses(skale_ima)
 
     schain_config = generate_schain_config(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,7 +12,7 @@ from typing import cast
 from unittest.mock import MagicMock, Mock
 
 import requests
-from eth_typing import ChecksumAddress, HexAddress
+from eth_typing import ChecksumAddress, HexAddress, HexStr
 from skale.dataclasses.schain_options import AllocationType, SchainOptions
 from skale.types.node import NodeId
 from skale.types.schain import SchainName, SchainStructure
@@ -147,7 +147,7 @@ def get_schain_struct(_test_schain_name) -> SchainStructure:
         generation=1,
         mainnet_owner=TEST_MAINNET_OWNER_ADDRESS,
         originator=TEST_ORIGINATOR_ADDRESS,
-        options=SchainOptions(True, True, AllocationType.DEFAULT),
+        options=SchainOptions(True, True, AllocationType.DEFAULT, HexStr('0x01'), None, None),
         index_in_owner_list=0,
         lifetime=3600,
         start_date=100000000,


### PR DESCRIPTION
This pull request introduces support for dynamic gas pricing configuration in the SKALE chain node configuration. The main updates allow for specifying minimum and maximum gas prices, as well as external gas difficulty, in both the configuration code and the test suite. These changes ensure that dynamic pricing parameters are properly handled and tested throughout the codebase.

**Dynamic Pricing Support:**

* Added `min_gas_price` and `max_gas_price` fields to `CurrentNodeInfo`, and updated the `to_dict` method to include `dynamicPricingMinPrice`, `dynamicPricingStartPrice`, and `dynamicPricingMaxPrice` when these fields are set. [[1]](diffhunk://#diff-165dfb9946b329ea7f2ed77c7b3a4dffa04466c7e1a7b72d8af1b1b91eada3a6R47-R49) [[2]](diffhunk://#diff-165dfb9946b329ea7f2ed77c7b3a4dffa04466c7e1a7b72d8af1b1b91eada3a6R62-R70)
* Updated the `generate_current_node_info` function to accept and pass through `min_gas_price` and `max_gas_price` from `schain.options`.
* Modified the `SchainOptions` construction in `manager_cache_helper.py` and test utilities to include `external_gas_difficulty`, `min_gas_price`, and `max_gas_price`. [[1]](diffhunk://#diff-a2ea2dae968a9c7382a9aa8bb4980a0356dbd2eb4dac92fe7fcbb87e53a678d1R92-R94) [[2]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L150-R150)

**Configuration and Dependency Updates:**

* Updated the `generate_schain_config` function to include `externalGasDifficulty` in the dynamic parameters for the base config.
* Bumped the `skale.py` dependency to version `7.11dev5` in `pyproject.toml` to support new features.

**Testing Enhancements:**

* Added a new test `test_generate_schain_config_with_dynamic_pricing` to verify that dynamic pricing fields are correctly set in the generated config.
* Updated test imports and utility functions to support the new fields and types. [[1]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L15-R15) [[2]](diffhunk://#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6L150-R150)