### PR TITLE
remove get current nodes from schains cleaner

### DIFF
--- a/core/schains/cleaner.py
+++ b/core/schains/cleaner.py
@@ -29,7 +29,6 @@ from sgx import SgxClient
 from skale import SkaleManager
 from skale.types.node import NodeId
 from skale.types.schain import SchainName, SchainStructure
-from skale.utils.helper import schain_name_to_hash
 from skale_core.settings import FairSettings, SkaleSettings, get_settings
 
 from core.chain.runner import get_container_name, is_exited
@@ -38,7 +37,7 @@ from core.config.schain.directory import schain_config_dir
 from core.dkg.utils import get_secret_key_share_filepath
 from core.firewall.utils import cleanup_firewall_for_schain, get_default_rule_controller
 from core.manager_cache import ManagerCache
-from core.node import get_current_nodes, get_skale_node_version
+from core.node import get_skale_node_version
 from core.node_config import NodeConfig
 from core.schains.external_config import ExternalConfig
 from core.schains.process import ProcessReport, terminate_process
@@ -232,11 +231,9 @@ def remove_schain(
     delete_bls_keys(skale, schain_name)
 
     sync_agent_ranges = manager_cache.sync_ranges
-    schain_hash = schain_name_to_hash(schain_name)
     rotation_data = skale.node_rotation.get_rotation(schain_name)
     rotation_id = rotation_data.rotation_counter
     estate = ExternalConfig(name=schain_name).get()
-    current_nodes = get_current_nodes(skale, schain_hash, manager_cache)
     group_index = skale.schains.name_to_group_id(schain_name)
     last_dkg_successful = skale.dkg.is_last_dkg_successful(group_index)
 
@@ -246,7 +243,6 @@ def remove_schain(
         sync_agent_ranges,
         rotation_id=rotation_id,
         last_dkg_successful=last_dkg_successful,
-        current_nodes=current_nodes,
         estate=estate,
         dutils=dutils,
     )
@@ -258,7 +254,6 @@ def cleanup_schain(
     sync_agent_ranges: list,
     rotation_id: int,
     last_dkg_successful: bool,
-    current_nodes: list,
     estate: ExternalConfig,
     dutils=None,
 ) -> None:
@@ -273,7 +268,7 @@ def cleanup_schain(
         rule_controller=rc,
         stream_version=stream_version,
         schain_record=schain_record,
-        current_nodes=current_nodes,
+        current_nodes=[],
         rotation_id=rotation_id,
         estate=estate,
         last_dkg_successful=last_dkg_successful,

--- a/tests/schains/cleaner_test.py
+++ b/tests/schains/cleaner_test.py
@@ -240,7 +240,6 @@ def test_cleanup_schain(
     schain_db,
     node_config,
     schain_on_contracts,
-    current_nodes,
     estate,
     dutils,
     secret_key,
@@ -251,7 +250,6 @@ def test_cleanup_schain(
     cleanup_schain(
         node_config.id,
         schain_name,
-        current_nodes=current_nodes,
         sync_agent_ranges=[],
         last_dkg_successful=True,
         rotation_id=0,


### PR DESCRIPTION
This pull request refactors the `cleaner.py` logic for removing and cleaning up an schain by eliminating the `current_nodes` parameter from related functions and tests. The change simplifies function signatures and standardizes the use of an empty list for `current_nodes` where it was previously dynamically determined.

**Refactoring and Simplification:**

* Removed the import and usage of `get_current_nodes` and the `current_nodes` parameter from the `remove_schain` and `cleanup_schain` functions in `core/schains/cleaner.py`, and now always passes an empty list for `current_nodes` in cleanup. [[1]](diffhunk://#diff-56ec902730c4b36bb1b710f2194e53d615a6dfe11aa2203ca4c0c7c967d37581L41-R40) [[2]](diffhunk://#diff-56ec902730c4b36bb1b710f2194e53d615a6dfe11aa2203ca4c0c7c967d37581L235-L239) [[3]](diffhunk://#diff-56ec902730c4b36bb1b710f2194e53d615a6dfe11aa2203ca4c0c7c967d37581L249) [[4]](diffhunk://#diff-56ec902730c4b36bb1b710f2194e53d615a6dfe11aa2203ca4c0c7c967d37581L261) [[5]](diffhunk://#diff-56ec902730c4b36bb1b710f2194e53d615a6dfe11aa2203ca4c0c7c967d37581L276-R271)

**Testing Adjustments:**

* Updated the `test_cleanup_schain` test in `tests/schains/cleaner_test.py` to remove the `current_nodes` parameter, reflecting the changes in the function signature. [[1]](diffhunk://#diff-74354ff49e6cff14922e4015d789b426f8ba12cdb5c6ad92414aa10cb8bf3d55L243) [[2]](diffhunk://#diff-74354ff49e6cff14922e4015d789b426f8ba12cdb5c6ad92414aa10cb8bf3d55L254)