### PR TITLE
fix schains api - add to_dict

### DIFF
--- a/tests/routes/schains_test.py
+++ b/tests/routes/schains_test.py
@@ -11,7 +11,7 @@ from skale_core.settings import get_settings
 
 from core.config.schain.file_manager import ConfigFileManager
 from core.node_config import NodeConfig
-from tests.utils import get_bp_data, get_test_rule_controller
+from tests.utils import get_bp_data, get_schain_struct, get_test_rule_controller
 from web.helper import get_api_url
 from web.models.schain import SChainRecord, upsert_schain_record
 from web.routes.schains import schains_bp
@@ -63,6 +63,28 @@ def test_schain_config(skale_bp, skale, schain_config, schain_on_contracts):
 def test_schains_list(skale_bp, skale):
     data = get_bp_data(skale_bp, get_api_url(BLUEPRINT_NAME, 'list'))
     assert data == {'payload': [], 'status': 'ok'}
+
+
+def test_schains_list_serialization(skale_bp, skale):
+    def schains_for_node_mock(self, node_id):
+        return [
+            get_schain_struct(_test_schain_name='test-schain1'),
+            get_schain_struct(_test_schain_name='test-schain2'),
+            get_schain_struct(_test_schain_name=''),
+        ]
+
+    with mock.patch(
+        'skale.contracts.manager.schains.SChains.schains_for_node',
+        schains_for_node_mock,
+    ):
+        data = get_bp_data(skale_bp, get_api_url(BLUEPRINT_NAME, 'list'))
+        assert data['status'] == 'ok'
+        payload = data['payload']
+        assert len(payload) == 2
+        assert payload[0]['name'] == 'test-schain1'
+        assert payload[1]['name'] == 'test-schain2'
+        for schain in payload:
+            assert isinstance(schain['schain_hash'], str)
 
 
 def schain_config_exists_mock(schain):

--- a/web/routes/schains.py
+++ b/web/routes/schains.py
@@ -18,9 +18,9 @@
 #   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-from dataclasses import asdict
 
 from flask import Blueprint, g, request
+from skale import SkaleManager
 
 from core.chain.status import init_skaled_status
 from core.config.endpoint import get_base_port_from_config
@@ -82,10 +82,11 @@ def schain_config():
 def schains_list():
     logger.debug(request)
     node_id = g.config.id
+    skale: SkaleManager = g.skale
     if node_id is None:
         return construct_err_response(msg='No node installed')
     schains_list = [
-        asdict(s) for s in g.skale.schains.schains_for_node(node_id) if s and s.name != ''
+        s.to_dict() for s in skale.schains.schains_for_node(node_id) if s and s.name != ''
     ]
     return construct_ok_response(schains_list)
 


### PR DESCRIPTION
This pull request improves the serialization logic for the `/schains/list` API endpoint and adds a new test to validate the changes. The main focus is on ensuring that only valid schain objects are returned and properly serialized, and that the test suite covers this behavior.

**Test improvements:**

* Added `test_schains_list_serialization` to verify that only schains with non-empty names are included in the API response and that their fields are correctly serialized.
* Updated test imports to include `get_schain_struct` for generating schain objects in tests.

**Serialization and endpoint logic:**

* Changed the `/schains/list` endpoint to use the `to_dict()` method for schain serialization instead of `asdict`, ensuring custom serialization logic is applied.
* Removed the unused `asdict` import from `web/routes/schains.py` since serialization now relies on `to_dict()`.