### PR TITLE
Develop to beta - DKG fix

### DIFF
--- a/core/dkg/client.py
+++ b/core/dkg/client.py
@@ -127,10 +127,18 @@ class BaseDKGClient(ABC):
         self.sent_secret_key_contribution = self.sgx.get_secret_key_contribution_v2(
             self.poly_name, self.public_keys
         )
-        self.incoming_secret_key_contribution[self.node_id_dkg] = self.sent_secret_key_contribution[
+
+        chunk = self.sent_secret_key_contribution[
             self.node_id_dkg * 192 : (self.node_id_dkg + 1)  # noqa
             * 192
         ]
+
+        # SGX format comes as:    [secret:64][public:128]
+        # events from SC come as: [public:128][secret:64]
+        # we assume later on every secret key contribution follows format from events, so
+        # we need to convert to it                                [public:128]   [secret:64]
+        self.incoming_secret_key_contribution[self.node_id_dkg] = chunk[64:192] + chunk[:64]
+
         return convert_str_to_key_share(self.sent_secret_key_contribution, self.n)
 
     @sgx_unreachable_retry

--- a/core/dkg/schain/utils.py
+++ b/core/dkg/schain/utils.py
@@ -260,6 +260,14 @@ def generate_bls_keys(dkg_client):
         common_public_key = dkg_client.get_common_bls_public_key()
     except Exception as err:
         raise DKGKeyGenerationError(err)
+
+    if dkg_client.public_key != bls_public_keys[dkg_client.node_id_dkg]:
+        raise DKGKeyGenerationError(
+            f'sChain {schain_name}: generated DKG public key for node '
+            f'{dkg_client.node_id_dkg} does not match the BLS public key stored '
+            f'in the smart contract.'
+        )
+
     dkg_client.last_completed_step = DKGStep.KEY_GENERATION
     return {
         'common_public_key': common_public_key,

--- a/core/dkg/schain/utils.py
+++ b/core/dkg/schain/utils.py
@@ -246,6 +246,16 @@ def get_common_bls_public_key(skale, schain_hash: SchainHash) -> list[str]:
     return [elem for coord in raw_common_public_key for elem in coord]
 
 
+def normalize_bls_public_key(public_key) -> str:
+    """
+    Normalizes bls public key from list of strings format to string ':' (colon)
+    separated format.
+    """
+    if isinstance(public_key, str):
+        return public_key
+    return ':'.join(str(elem) for elem in public_key)
+
+
 def generate_bls_keys(dkg_client):
     schain_name = dkg_client.chain_name
     try:
@@ -261,11 +271,15 @@ def generate_bls_keys(dkg_client):
     except Exception as err:
         raise DKGKeyGenerationError(err)
 
-    if dkg_client.public_key != bls_public_keys[dkg_client.node_id_dkg]:
+    local_public_key = normalize_bls_public_key(dkg_client.public_key)
+    if local_public_key != bls_public_keys[dkg_client.node_id_dkg]:
         raise DKGKeyGenerationError(
-            f'sChain {schain_name}: generated DKG public key for node '
-            f'{dkg_client.node_id_dkg} does not match the BLS public key stored '
-            f'in the smart contract.'
+            f'sChain {schain_name}: generated DKG public key mismatch. '
+            f'contract_node_id={dkg_client.node_id_contract}, '
+            f'dkg_index={dkg_client.node_id_dkg}, '
+            f'node_ids_dkg={dkg_client.node_ids_dkg}, '
+            f'local_public_key={local_public_key}, '
+            f'bls_public_keys={bls_public_keys}'
         )
 
     dkg_client.last_completed_step = DKGStep.KEY_GENERATION

--- a/tests/dkg_test/main_test.py
+++ b/tests/dkg_test/main_test.py
@@ -261,6 +261,7 @@ def run_node_dkg(
     index: int,
     node_id: int,
     runs: tuple[DKGRunType] = (DKGRunType.NORMAL,),
+    configure_client=None,
 ):
     init_schain_config_dir(schain_name)
     sgx_key_name = skale.wallet._key_name
@@ -276,6 +277,9 @@ def run_node_dkg(
         with dkg_test_client(
             skale, node_id, schain_name, sgx_key_name, rotation_id, run_type
         ) as dkg_client:
+            # allow per-test custom dkg client configuration
+            if configure_client:
+                configure_client(dkg_client)
             logger.info('ID skale %d', id(dkg_client.skale))
             try:
                 dkg_result = run_dkg(skale, dkg_client, schain_name, rotation_id)
@@ -315,6 +319,29 @@ def remove_nodes(skale, nodes):
         skale.nodes.init_exit(node_id)
         skale.manager.node_exit(node_id)
 
+def filter_own_broadcast_event(remove_own_events):
+    """
+    Returns a function that can be used to configure DKG client to
+    filter out its own broadcast events, so it will be forced to use 
+    local SGX data instead of data from blockchain.
+    """
+    def configure(dkg_client):
+        original_get_events = dkg_client.broadcast_filter.get_events
+
+        def get_events_without_own(*args, **kwargs):
+            events = original_get_events(*args, **kwargs)
+            own_events = [
+                event for event in events if event.nodeIndex == dkg_client.node_id_contract
+            ]
+
+            remove_own_events.extend(own_events)
+            return [
+                event for event in events
+                if event.nodeIndex != dkg_client.node_id_contract
+            ]
+        dkg_client.broadcast_filter.get_events = get_events_without_own
+
+    return configure
 
 class TestDKG:
     @pytest.fixture
@@ -414,6 +441,42 @@ class TestDKG:
 
         restore_dkg_keys_data = sorted([r.keys_data for r in results], key=lambda d: d['n'])
         assert regular_dkg_keys_data == restore_dkg_keys_data
+
+    @pytest.mark.timeout(DKG_TEST_TIMEOUT)
+    @mock.patch('core.dkg.schain.utils.BROADCAST_DATA_SEARCH_SLEEP', TEST_BROADCAST_SLEEP)
+    def test_dkg_uses_local_sgx_data_when_own_broadcast_event_missing(
+        self, skale, schain_creation_data, skale_sgx_instances, nodes, dkg_timeout, schain
+    ):
+        schain_name, _ = schain_creation_data
+        nodes.sort(key=lambda x: x['node_id'])
+        runners = get_dkg_runners(skale, skale_sgx_instances, schain_name, nodes)
+
+        # node that will miss its broadcast & use local sgx data
+        target_index = N_OF_NODES - 1
+        removed_own_events = []
+
+        runners[target_index] = functools.partial(
+            run_node_dkg,
+            skale_sgx_instances[target_index],
+            schain_name,
+            target_index,
+            nodes[target_index]['node_id'],
+            configure_client=filter_own_broadcast_event(removed_own_events),
+        )
+
+        results = exec_dkg_runners(runners)
+
+        assert removed_own_events
+        assert len(results) == N_OF_NODES
+        assert is_last_dkg_finished(skale, schain_name)
+
+        for i, result in enumerate(results):
+            assert result.status.is_done(), f'node {i} failed: {result}'
+            assert result.step == DKGStep.KEY_GENERATION
+            keys_data = result.keys_data
+            assert keys_data is not None
+        gid = schain_name_to_hash(schain_name)
+        assert skale.dkg.is_last_dkg_successful(gid)
 
     @pytest.mark.timeout(DKG_TEST_TIMEOUT)
     @mock.patch('core.dkg.schain.utils.BROADCAST_DATA_SEARCH_SLEEP', TEST_BROADCAST_SLEEP)

--- a/tests/dkg_test/main_test.py
+++ b/tests/dkg_test/main_test.py
@@ -322,7 +322,7 @@ def remove_nodes(skale, nodes):
 def filter_own_broadcast_event(remove_own_events):
     """
     Returns a function that can be used to configure DKG client to
-    filter out its own broadcast events, so it will be forced to use 
+    filter out its own broadcast events, so it will be forced to use
     local SGX data instead of data from blockchain.
     """
     def configure(dkg_client):

--- a/tests/dkg_test/utils_test.py
+++ b/tests/dkg_test/utils_test.py
@@ -1,0 +1,90 @@
+import pytest
+
+from core.dkg.schain.utils import generate_bls_keys
+from core.dkg.structures import DKGStep
+from core.dkg.utils import DKGKeyGenerationError
+
+
+class DKGClientMock:
+    def __init__(
+        self,
+        public_key=None,
+        bls_public_keys=None,
+        bls_key_generated=False,
+        fail_on_public_keys=False,
+    ):
+        self.chain_name = 'test-schain'
+        self.public_key = public_key or ['1', '2', '3', '4']
+        self.bls_public_keys = bls_public_keys or ['1:2:3:4']
+        self.bls_key_generated = bls_key_generated
+        self.fail_on_public_keys = fail_on_public_keys
+        self.common_public_key = ['common']
+        self.node_id_contract = 11
+        self.node_id_dkg = 0
+        self.node_ids_dkg = {0: 11}
+        self.t = 1
+        self.n = 1
+        self.bls_name = 'BLS_KEY:test'
+        self.generated = False
+        self.fetched = False
+        self.last_completed_step = DKGStep.NONE
+
+    def is_bls_key_generated(self):
+        return self.bls_key_generated
+
+    def generate_bls_key(self):
+        self.generated = True
+        return 'encrypted-key'
+
+    def fetch_bls_public_key(self):
+        self.fetched = True
+
+    def get_bls_public_keys(self):
+        if self.fail_on_public_keys:
+            raise RuntimeError('public key calculation failed')
+        return self.bls_public_keys
+
+    def get_common_bls_public_key(self):
+        return self.common_public_key
+
+
+def test_generate_bls_keys_normalizes_generated_public_key_list():
+    dkg_client = DKGClientMock(public_key=['1', '2', '3', '4'])
+
+    keys_data = generate_bls_keys(dkg_client)
+
+    assert dkg_client.generated
+    assert not dkg_client.fetched
+    assert dkg_client.last_completed_step == DKGStep.KEY_GENERATION
+    assert keys_data['public_key'] == ['1', '2', '3', '4']
+    assert keys_data['bls_public_keys'] == ['1:2:3:4']
+
+
+def test_generate_bls_keys_accepts_existing_string_public_key():
+    dkg_client = DKGClientMock(public_key='1:2:3:4', bls_key_generated=True)
+
+    keys_data = generate_bls_keys(dkg_client)
+
+    assert not dkg_client.generated
+    assert dkg_client.fetched
+    assert dkg_client.last_completed_step == DKGStep.KEY_GENERATION
+    assert keys_data['public_key'] == '1:2:3:4'
+
+
+def test_generate_bls_keys_raises_on_public_key_mismatch():
+    dkg_client = DKGClientMock(
+        public_key=['1', '2', '3', '4'],
+        bls_public_keys=['4:3:2:1'],
+    )
+
+    with pytest.raises(DKGKeyGenerationError, match='generated DKG public key mismatch'):
+        generate_bls_keys(dkg_client)
+
+
+def test_generate_bls_keys_wraps_key_generation_errors():
+    dkg_client = DKGClientMock(fail_on_public_keys=True)
+
+    with pytest.raises(DKGKeyGenerationError) as err:
+        generate_bls_keys(dkg_client)
+
+    assert isinstance(err.value.args[0], RuntimeError)


### PR DESCRIPTION
This pull request introduces several improvements and new tests for the DKG (Distributed Key Generation) process, focusing on BLS key normalization, validation, and enhanced testability. The main changes include normalizing BLS public keys for consistent comparison, adding strict validation to catch mismatches, and expanding the test suite to cover these scenarios. Additionally, the DKG test harness is made more flexible to allow custom client configuration and simulate edge cases.

**BLS Key Normalization and Validation:**

- Added a new function `normalize_bls_public_key` in `core/dkg/schain/utils.py` to ensure BLS public keys are consistently formatted as colon-separated strings, regardless of their original type.
- Updated `generate_bls_keys` to use the normalization function and to raise a `DKGKeyGenerationError` if the locally generated public key does not match the one expected from the contract, improving error detection and debugging.

**Test Suite Enhancements:**

- Added a new test module `tests/dkg_test/utils_test.py` with comprehensive unit tests for BLS key normalization, mismatch detection, and error handling in `generate_bls_keys`.
- Modified the DKG test harness (`run_node_dkg` in `tests/dkg_test/main_test.py`) to accept a `configure_client` callback, enabling per-test customization of the DKG client for more flexible testing. [[1]](diffhunk://#diff-6e4a2859731487f3c342b9fb392429eae5c98bec01ec484df12584f58a547efcR264) [[2]](diffhunk://#diff-6e4a2859731487f3c342b9fb392429eae5c98bec01ec484df12584f58a547efcR280-R282)
- Added a utility function `filter_own_broadcast_event` and a new test `test_dkg_uses_local_sgx_data_when_own_broadcast_event_missing` to simulate and verify the DKG client's behavior when its own broadcast event is missing, ensuring it falls back to local SGX data as intended. [[1]](diffhunk://#diff-6e4a2859731487f3c342b9fb392429eae5c98bec01ec484df12584f58a547efcR322-R344) [[2]](diffhunk://#diff-6e4a2859731487f3c342b9fb392429eae5c98bec01ec484df12584f58a547efcR445-R480)

**Secret Key Contribution Format Adjustment:**

- Updated the secret key contribution logic in `core/dkg/client.py` to reorder the SGX key contribution chunk for compatibility with the expected event format, ensuring correct downstream processing.