### PR TITLE
Fix limits

### DIFF
--- a/core/chain/containers.py
+++ b/core/chain/containers.py
@@ -1,5 +1,3 @@
-# ABOUTME: Monitors skaled and IMA containers and starts them when required.
-# ABOUTME: Keeps container lifecycle actions aligned with chain state and resource limits.
 #   -*- coding: utf-8 -*-
 #
 #   This file is part of SKALE Admin

--- a/core/chain/containers.py
+++ b/core/chain/containers.py
@@ -1,3 +1,5 @@
+# ABOUTME: Monitors skaled and IMA containers and starts them when required.
+# ABOUTME: Keeps container lifecycle actions aligned with chain state and resource limits.
 #   -*- coding: utf-8 -*-
 #
 #   This file is part of SKALE Admin
@@ -59,6 +61,7 @@ def monitor_skaled_container(
     dutils: Optional[DockerUtils] = None,
     passive_node: bool = False,
     historic_state: bool = False,
+    part_of_node: Optional[int] = None,
 ) -> None:
     dutils = dutils or DockerUtils()
     logger.info(f'Monitoring skaled container for {chain_name}')
@@ -83,6 +86,7 @@ def monitor_skaled_container(
             snapshot_from=snapshot_from,
             passive_node=passive_node,
             historic_state=historic_state,
+            part_of_node=part_of_node,
         )
         update_ssl_change_date(chain_record)
         chain_record.reset_failed_counters()
@@ -118,6 +122,7 @@ def monitor_ima_container(
     ima_data: ImaData,
     migration_ts: int = 0,
     dutils: DockerUtils | None = None,
+    part_of_node: Optional[int] = None,
 ) -> None:
     dutils = dutils or DockerUtils()
 
@@ -153,7 +158,12 @@ def monitor_ima_container(
             '%s No IMA container, creating, image %s, time frame %d', chain_name, image, time_frame
         )
         run_ima_container(
-            chain_name, ima_data.chain_id, image=image, time_frame=time_frame, dutils=dutils
+            chain_name,
+            ima_data.chain_id,
+            image=image,
+            time_frame=time_frame,
+            dutils=dutils,
+            part_of_node=part_of_node,
         )
     else:
         logger.debug('Chain %s: IMA container exists, but not running, skipping', chain_name)

--- a/core/chain/runner.py
+++ b/core/chain/runner.py
@@ -1,5 +1,3 @@
-# ABOUTME: Builds Docker run arguments for skaled and IMA chain containers.
-# ABOUTME: Applies image, volume, command, and resource settings during startup.
 #   -*- coding: utf-8 -*-
 #
 #   This file is part of SKALE Admin

--- a/core/chain/runner.py
+++ b/core/chain/runner.py
@@ -1,3 +1,5 @@
+# ABOUTME: Builds Docker run arguments for skaled and IMA chain containers.
+# ABOUTME: Applies image, volume, command, and resource settings during startup.
 #   -*- coding: utf-8 -*-
 #
 #   This file is part of SKALE Admin
@@ -212,7 +214,7 @@ def run_skaled_container(
 ):
     cpu_limit = None
     mem_limit = None
-    if part_of_node and not passive_node and not is_fair():
+    if part_of_node is not None and not passive_node and not is_fair():
         schain_type = get_schain_type(part_of_node)
         cpu_limit = get_schain_limit(schain_type, MetricType.cpu_shares)
         mem_limit = get_schain_limit(schain_type, MetricType.mem)
@@ -259,7 +261,7 @@ def run_ima_container(
     cpu_limit = None
     mem_limit = None
 
-    if part_of_node:
+    if part_of_node is not None:
         schain_type = get_schain_type(part_of_node)
         cpu_limit = get_ima_limit(schain_type, MetricType.cpu_shares)
         mem_limit = get_ima_limit(schain_type, MetricType.mem)

--- a/core/monitor/schain/action_skaled.py
+++ b/core/monitor/schain/action_skaled.py
@@ -1,5 +1,3 @@
-# ABOUTME: Runs schain lifecycle actions for skaled, IMA, volumes, and firewall rules.
-# ABOUTME: Connects chain metadata to container monitoring and resource-aware startup.
 #   -*- coding: utf-8 -*-
 #
 #  This file is part of SKALE Admin

--- a/core/monitor/schain/action_skaled.py
+++ b/core/monitor/schain/action_skaled.py
@@ -1,3 +1,5 @@
+# ABOUTME: Runs schain lifecycle actions for skaled, IMA, volumes, and firewall rules.
+# ABOUTME: Connects chain metadata to container monitoring and resource-aware startup.
 #   -*- coding: utf-8 -*-
 #
 #  This file is part of SKALE Admin
@@ -127,6 +129,7 @@ class SkaledActionManager(BaseSkaledActionManager):
             dutils=self.dutils,
             passive_node=is_passive(),
             historic_state=self.node_options.historic_state,
+            part_of_node=self.schain.part_of_node,
         )
         time.sleep(self.post_run_delay)
         return True
@@ -206,7 +209,11 @@ class SkaledActionManager(BaseSkaledActionManager):
             ima_data = ImaData(linked=self.econfig.ima_linked, chain_id=self.econfig.chain_id)
             logger.info('Running IMA container watchman')
             monitor_ima_container(
-                self.chain_name, ima_data, migration_ts=migration_ts, dutils=self.dutils
+                self.chain_name,
+                ima_data,
+                migration_ts=migration_ts,
+                dutils=self.dutils,
+                part_of_node=self.schain.part_of_node,
             )
         else:
             logger.info('ima_container - ok')

--- a/tests/schains/monitor/action/skaled_action_test.py
+++ b/tests/schains/monitor/action/skaled_action_test.py
@@ -1,3 +1,5 @@
+# ABOUTME: Exercises schain skaled action manager behavior for containers and related actions.
+# ABOUTME: Verifies action calls propagate chain state into Docker monitor operations.
 import datetime
 import json
 import os
@@ -40,6 +42,7 @@ def monitor_skaled_container_mock(
     dutils: Optional[DockerUtils] = None,
     passive_node: bool = False,
     historic_state: bool = False,
+    part_of_node: Optional[int] = None,
 ):
     if dutils is None:
         dutils = DockerUtils()
@@ -135,6 +138,7 @@ def test_skaled_container_with_snapshot_action(skaled_am: SkaledActionManager):
             dutils=skaled_am.dutils,
             passive_node=False,
             historic_state=False,
+            part_of_node=skaled_am.schain.part_of_node,
         )
         assert monitor_skaled_container_mock.call_count == 1
     finally:
@@ -161,6 +165,7 @@ def test_skaled_container_snapshot_delay_start_action(skaled_am: SkaledActionMan
             dutils=skaled_am.dutils,
             passive_node=False,
             historic_state=False,
+            part_of_node=skaled_am.schain.part_of_node,
         )
         assert monitor_skaled_container_mock.call_count == 1
     finally:

--- a/tests/schains/monitor/action/skaled_action_test.py
+++ b/tests/schains/monitor/action/skaled_action_test.py
@@ -1,5 +1,3 @@
-# ABOUTME: Exercises schain skaled action manager behavior for containers and related actions.
-# ABOUTME: Verifies action calls propagate chain state into Docker monitor operations.
 import datetime
 import json
 import os


### PR DESCRIPTION
This pull request introduces changes to better align container monitoring and startup logic with the state of the chain and its resource constraints. The main update is the propagation of the `part_of_node` parameter throughout the container lifecycle, ensuring that resource limits and container actions are accurately applied based on node membership. The changes also include improved documentation for key modules and updated tests to verify the new behavior.

**Container lifecycle and resource management:**

* Added the `part_of_node` parameter to `monitor_skaled_container` and `monitor_ima_container` functions in `core/chain/containers.py`, and ensured it is passed through from the schain action layer, enabling resource-aware container monitoring and startup. [[1]](diffhunk://#diff-15e03533aa22667716bbfb4ed2810f081e234f94f586ec1be5bd43bc39f134dfR64) [[2]](diffhunk://#diff-15e03533aa22667716bbfb4ed2810f081e234f94f586ec1be5bd43bc39f134dfR89) [[3]](diffhunk://#diff-15e03533aa22667716bbfb4ed2810f081e234f94f586ec1be5bd43bc39f134dfR125) [[4]](diffhunk://#diff-15e03533aa22667716bbfb4ed2810f081e234f94f586ec1be5bd43bc39f134dfL156-R166) [[5]](diffhunk://#diff-eb4983efd33b6ac6fdbcecc3c5717366b8343676259298ebbdc0099b810091f3R132) [[6]](diffhunk://#diff-eb4983efd33b6ac6fdbcecc3c5717366b8343676259298ebbdc0099b810091f3L209-R216)
* Updated logic in `run_skaled_container` and `run_ima_container` in `core/chain/runner.py` to only apply resource limits when `part_of_node` is not `None`, preventing unintended resource allocation. [[1]](diffhunk://#diff-985a2bf6700c2e5612b9acd3e4aaf0dcc6dfd21d797da0d2fa1ba29763ab203eL215-R217) [[2]](diffhunk://#diff-985a2bf6700c2e5612b9acd3e4aaf0dcc6dfd21d797da0d2fa1ba29763ab203eL262-R264)

**Documentation improvements:**

* Added `# ABOUTME` docstrings to the top of `core/chain/containers.py`, `core/chain/runner.py`, `core/monitor/schain/action_skaled.py`, and `tests/schains/monitor/action/skaled_action_test.py` to clarify the purpose and responsibilities of each module. [[1]](diffhunk://#diff-15e03533aa22667716bbfb4ed2810f081e234f94f586ec1be5bd43bc39f134dfR1-R2) [[2]](diffhunk://#diff-985a2bf6700c2e5612b9acd3e4aaf0dcc6dfd21d797da0d2fa1ba29763ab203eR1-R2) [[3]](diffhunk://#diff-eb4983efd33b6ac6fdbcecc3c5717366b8343676259298ebbdc0099b810091f3R1-R2) [[4]](diffhunk://#diff-2f3934abd1936a71a7b1dabdf7d667bce6d8663a379d20cc5ab989ab15436952R1-R2)

**Testing updates:**

* Updated test mocks and test cases in `skaled_action_test.py` to include the `part_of_node` parameter, ensuring that tests accurately reflect the new container monitoring logic. [[1]](diffhunk://#diff-2f3934abd1936a71a7b1dabdf7d667bce6d8663a379d20cc5ab989ab15436952R45) [[2]](diffhunk://#diff-2f3934abd1936a71a7b1dabdf7d667bce6d8663a379d20cc5ab989ab15436952R141) [[3]](diffhunk://#diff-2f3934abd1936a71a7b1dabdf7d667bce6d8663a379d20cc5ab989ab15436952R168)