### PR TITLE
Fix repair mode trigger

### DIFF
--- a/core/chain/containers.py
+++ b/core/chain/containers.py
@@ -61,10 +61,6 @@ def monitor_skaled_container(
     historic_state: bool = False,
     part_of_node: Optional[int] = None,
 ) -> bool:
-    """
-    Returns True if skaled container is present after the run,
-    False if starting the container was skipped
-    """
     dutils = dutils or DockerUtils()
     logger.info(f'Monitoring skaled container for {chain_name}')
 

--- a/core/chain/containers.py
+++ b/core/chain/containers.py
@@ -60,19 +60,23 @@ def monitor_skaled_container(
     passive_node: bool = False,
     historic_state: bool = False,
     part_of_node: Optional[int] = None,
-) -> None:
+) -> bool:
+    """
+    Returns True if skaled container is present after the run,
+    False if starting the container was skipped
+    """
     dutils = dutils or DockerUtils()
     logger.info(f'Monitoring skaled container for {chain_name}')
 
     if not is_volume_exists(chain_name, passive_node=passive_node, dutils=dutils):
         logger.error(f'Data volume for chain {chain_name} does not exist')
-        return
+        return False
 
     if skaled_status.exit_time_reached and abort_on_exit:
         logger.info(f'{chain_name} - Skipping container monitor: exit time reached')
         skaled_status.log()
         chain_record.reset_failed_counters()
-        return
+        return False
 
     if not is_container_exists(chain_name, dutils=dutils):
         logger.info(f"Chain {chain_name}: container doesn't exist")
@@ -89,13 +93,13 @@ def monitor_skaled_container(
         update_ssl_change_date(chain_record)
         chain_record.reset_failed_counters()
         chain_record.set_force_skaled_start(False)
-        return
+        return True
 
     if skaled_status.clear_data_dir and skaled_status.start_from_snapshot:
         logger.info(f'{chain_name} - Skipping container monitor: skaled should be repaired')
         skaled_status.log()
         chain_record.reset_failed_counters()
-        return
+        return False
 
     if is_skaled_container_failed(chain_name, dutils=dutils):
         restart_count = cast(int, chain_record.restart_count)
@@ -113,6 +117,7 @@ def monitor_skaled_container(
     else:
         chain_record.set_restart_count(0)
         chain_record.set_snapshot_from('')
+    return True
 
 
 def monitor_ima_container(

--- a/core/chain/status.py
+++ b/core/chain/status.py
@@ -142,6 +142,17 @@ def init_skaled_status(schain_name: str) -> SkaledStatus:
     return SkaledStatus(status_filepath)
 
 
+def rm_skaled_status(schain_name: str) -> None:
+    """
+    Remove skaled.status file. It lives outside of the data volume,
+    so it outlives the container it describes and has to be dropped explicitly
+    """
+    status_filepath = skaled_status_filepath(schain_name)
+    if os.path.isfile(status_filepath):
+        logger.info('Removing skaled status file %s', status_filepath)
+        os.remove(status_filepath)
+
+
 def get_skaled_status(schain_name: str) -> Optional[SkaledStatus]:
     status_path = skaled_status_filepath(schain_name)
     if os.path.isfile(status_path):

--- a/core/monitor/action_base.py
+++ b/core/monitor/action_base.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, Optional
 
 from core.chain.rpc import handle_failed_skaled_rpc
 from core.chain.runner import get_container_name, is_container_exists
-from core.chain.status import init_skaled_status
+from core.chain.status import init_skaled_status, rm_skaled_status
 from core.checks.base import BaseSkaledChecks
 from core.config.schain.file_manager import ConfigFileManager
 from core.firewall import IRuleController
@@ -185,6 +185,15 @@ class BaseSkaledActionManager(BaseActionManager):
         remove_skaled_container(self.name, dutils=self.dutils)
         time.sleep(self.schain_cleanup_timeout)
         remove_schain_volume(self.name, dutils=self.dutils)
+        return True
+
+    @BaseActionManager.monitor_block
+    def cleanup_skaled_state_files(self) -> bool:
+        """Drop skaled status and exit schedule left from the removed container"""
+        logger.info('Removing skaled state files')
+        rm_skaled_status(self.name)
+        if self.esfm.exists():
+            self.esfm.rm()
         return True
 
     @BaseActionManager.monitor_block

--- a/core/monitor/fair/action_skaled.py
+++ b/core/monitor/fair/action_skaled.py
@@ -96,7 +96,7 @@ class FairSkaledActionManager(BaseSkaledActionManager):
         else:
             logger.info('Skaled start mode: regular')
 
-        monitor_skaled_container(
+        started = monitor_skaled_container(
             self.chain_name,
             chain_record=self.chain_record,
             skaled_status=self.skaled_status,
@@ -108,7 +108,7 @@ class FairSkaledActionManager(BaseSkaledActionManager):
             historic_state=self.node_options.historic_state,
         )
         time.sleep(self.post_run_delay)
-        return True
+        return started
 
     @BaseActionManager.monitor_block
     def volume(self) -> bool:

--- a/core/monitor/schain/action_skaled.py
+++ b/core/monitor/schain/action_skaled.py
@@ -116,7 +116,7 @@ class SkaledActionManager(BaseSkaledActionManager):
             start_ts,
         )
         snapshot_from = self.ncli_status.snapshot_from if self.ncli_status else None
-        monitor_skaled_container(
+        started = monitor_skaled_container(
             self.chain_name,
             chain_record=self.chain_record,
             skaled_status=self.skaled_status,
@@ -130,7 +130,7 @@ class SkaledActionManager(BaseSkaledActionManager):
             part_of_node=self.schain.part_of_node,
         )
         time.sleep(self.post_run_delay)
-        return True
+        return started
 
     @BaseActionManager.monitor_block
     def volume(self) -> bool:

--- a/core/monitor/schain/monitor_skaled.py
+++ b/core/monitor/schain/monitor_skaled.py
@@ -75,11 +75,15 @@ class SnapshotSkaledMonitor(BaseSChainSkaledMonitor):
             self.am.firewall_rules()
         if not self.checks.volume:
             self.am.volume()
+        skaled_started = True
         if not self.checks.skaled_container:
-            self.am.skaled_container(download_snapshot=True)
+            skaled_started = self.am.skaled_container(download_snapshot=True, abort_on_exit=False)
         else:
             self.am.reset_restart_counter()
-        self.am.update_repair_ts(new_ts=int(time.time()))
+        if skaled_started:
+            self.am.update_repair_ts(new_ts=int(time.time()))
+        else:
+            logger.warning('Skaled was not started, keeping repair request')
 
 
 class RepairSkaledMonitor(BaseSChainSkaledMonitor):
@@ -95,15 +99,20 @@ class RepairSkaledMonitor(BaseSChainSkaledMonitor):
         )
         self.am.notify_repair_mode()
         self.am.cleanup_schain_docker_entity()
+        self.am.cleanup_skaled_state_files()
         if not self.checks.firewall_rules:
             self.am.firewall_rules()
         if not self.checks.volume:
             self.am.volume()
+        skaled_started = True
         if not self.checks.skaled_container:
-            self.am.skaled_container(download_snapshot=True)
+            skaled_started = self.am.skaled_container(download_snapshot=True, abort_on_exit=False)
         else:
             self.am.reset_restart_counter()
-        self.am.update_repair_ts(new_ts=int(time.time()))
+        if skaled_started:
+            self.am.update_repair_ts(new_ts=int(time.time()))
+        else:
+            logger.warning('Skaled was not started, keeping repair request')
 
 
 class BackupSkaledMonitor(BaseSChainSkaledMonitor):
@@ -117,13 +126,17 @@ class BackupSkaledMonitor(BaseSChainSkaledMonitor):
             self.am.volume()
         if not self.checks.firewall_rules:
             self.am.firewall_rules()
+        skaled_started = True
         if not self.checks.skaled_container:
-            self.am.skaled_container(download_snapshot=True)
+            skaled_started = self.am.skaled_container(download_snapshot=True, abort_on_exit=False)
         else:
             self.am.reset_restart_counter()
         if not self.checks.ima_container:
             self.am.ima_container()
-        self.am.disable_backup_run()
+        if skaled_started:
+            self.am.disable_backup_run()
+        else:
+            logger.warning('Skaled was not started, keeping backup mode')
 
 
 class RecreateSkaledMonitor(BaseSChainSkaledMonitor):
@@ -224,7 +237,11 @@ class NewNodeSkaledMonitor(BaseSChainSkaledMonitor):
         if not self.checks.firewall_rules:
             self.am.firewall_rules()
         if not self.checks.skaled_container:
-            self.am.skaled_container(download_snapshot=True, start_ts=self.am.upstream_finish_ts)
+            self.am.skaled_container(
+                download_snapshot=True,
+                start_ts=self.am.upstream_finish_ts,
+                abort_on_exit=False,
+            )
         else:
             self.am.reset_restart_counter()
         if not self.checks.ima_container:


### PR DESCRIPTION
### Fix repair mode wiping sChain data without downloading a snapshot

#### Problem

`RepairSkaledMonitor` removes the skaled container and the data volume, then calls
`skaled_container(download_snapshot=True)`. But `skaled.status` lives in the chain config
dir, not on the volume, so a stale `ExitTimeReached: true` survives the wipe and
`monitor_skaled_container` aborts early (`abort_on_exit` defaults to `True`). Repair still
bumps `repair_ts`, consuming the request, so ~3 minutes later `UpdateConfigSkaledMonitor`
starts skaled with `abort_on_exit=False` and **no** `--download-snapshot` on the now-empty
volume. The node comes up at block 0 and can never catch up from genesis
(`CatchupClientAgent: Server error in catchup response:5`) — repair leaves the node
strictly worse off, with no automatic way back.

#### Changes

- `Repair`/`Snapshot`/`Backup`/`NewNode` monitors pass `abort_on_exit=False`. Each has
  already decided to start from a snapshot; the exit state of a container that is gone has
  no say in that. `Regular`/`ReloadGroup`/`ReloadIp` still honour a scheduled exit.
- `monitor_skaled_container` now returns whether the container is present, propagated
  through `skaled_container()`. `repair_ts` and `backup_run` are consumed only when skaled
  actually started — otherwise the request stays pending and the next round retries.
- New `cleanup_skaled_state_files()` drops the stale `skaled.status` and `rotation.json`
  during repair. This also stops the follow-on misfires: `is_config_update_time` and
  `is_skaled_repair_internal` reading a dead container's flags, and `schedule_skaled_exit`
  refusing to set the next rotation exit while either file is present.
