### PR TITLE
Fix admin healthcheck

### DIFF
--- a/healthchecks/admin.py
+++ b/healthchecks/admin.py
@@ -20,12 +20,17 @@
 import os
 import time
 
+from tools.constants.logs import ADMIN_LOG_PATH
+
 MAX_ALLOWED_LOG_TIME_DIFF = os.getenv('MAX_ALLOWED_LOG_TIME_DIFF', 600)
-ADMIN_LOG_FILEPATH = '/skale_node_data/log/admin.log'
 
 
 def run_healthcheck():
-    modification_time = os.path.getmtime(ADMIN_LOG_FILEPATH)
+    try:
+        modification_time = os.path.getmtime(ADMIN_LOG_PATH)
+    except OSError as err:
+        print(f'Cannot stat {ADMIN_LOG_PATH}: {err}')
+        exit(4)
     current_time = time.time()
     time_diff = current_time - modification_time
 


### PR DESCRIPTION
This pull request fixes the admin healthcheck 

**Problem**                                                                                                                                                                                           
                                                                                                                                                                                                    
  The `sk_admin` healthcheck fails on every node: it checks the mtime of a hardcoded path `/skale_node_data/log/admin.log`, but the `${SKALE_DIR}/node_data:/skale_node_data` mount was removed from the admin service in `skale-node`, so this path no longer exists inside the container. The script crashed on every run and the container was reported unhealthy regardless of its actual state:
                                                                                                                                                                     
`  FileNotFoundError: [Errno 2] No such file or directory: '/skale_node_data/log/admin.log' `                                                                                                         
                                                                                                                                                                                                    
**Fix**                                                                                                                                                                                              
                                                                                                                                                                                                    
  - Takes the log path from `tools.constants.logs.ADMIN_LOG_PATH` - the same constant the admin logger writes to (`/skale_vol/node_data/log/admin.log`) - instead of duplicating it, so the healthcheck cannot diverge from the logger again. The import pulls stdlib only, so the check stays lightweight.                                                                                                                                              
  - Handles a missing/inaccessible log file explicitly: prints a clear message and exits with a dedicated code instead of an unhandled traceback.