### PR TITLE
Improve error handling and exit code on worker failures

### DIFF
--- a/skale_admin.py
+++ b/skale_admin.py
@@ -61,7 +61,6 @@ logger = logging.getLogger(__name__)
 
 ACTIVE_SLEEP_INTERVAL = 240
 PASSIVE_SLEEP_INTERVAL = 360
-WORKER_RESTART_SLEEP_INTERVAL = 2
 
 
 def init_db() -> None:
@@ -79,10 +78,7 @@ def monitor_active(skale: SkaleManager, skale_ima: SkaleIma, node_config: NodeCo
             logger.exception('Process manager procedure failed!')
         logger.info(f'Sleeping for {ACTIVE_SLEEP_INTERVAL}s after run_process_manager')
         time.sleep(ACTIVE_SLEEP_INTERVAL)
-        try:
-            run_cleaner(skale, node_config, manager_cache)
-        except Exception:
-            logger.exception('Cleaner procedure failed!')
+        run_cleaner(skale, node_config, manager_cache)
         logger.info(f'Sleeping for {ACTIVE_SLEEP_INTERVAL}s after run_cleaner')
         time.sleep(ACTIVE_SLEEP_INTERVAL)
 
@@ -169,25 +165,23 @@ def init_active() -> None:
 
 def run_active() -> None:
     logger.info('Starting active node worker')
-    while True:
-        try:
-            init_active()
-            worker_active()
-        except Exception:
-            logger.exception('Admin worker failed')
-        time.sleep(WORKER_RESTART_SLEEP_INTERVAL)
+    try:
+        init_active()
+        worker_active()
+    except Exception:
+        logger.exception('Admin worker failed')
+        exit(1)
 
 
 def run_passive() -> None:
     logger.info('Starting passive node worker')
     st = get_settings(SkalePassiveSettings)
-    while True:
-        try:
-            init_db()
-            worker_passive(st.schain_name)
-        except Exception:
-            logger.exception('Sync node worker failed')
-        time.sleep(WORKER_RESTART_SLEEP_INTERVAL)
+    try:
+        init_db()
+        worker_passive(st.schain_name)
+    except Exception:
+        logger.exception('Sync node worker failed')
+        exit(1)
 
 
 def main() -> None:

--- a/skale_admin.py
+++ b/skale_admin.py
@@ -62,7 +62,6 @@ logger = logging.getLogger(__name__)
 ACTIVE_SLEEP_INTERVAL = 240
 PASSIVE_SLEEP_INTERVAL = 360
 WORKER_RESTART_SLEEP_INTERVAL = 2
-ERROR_SLEEP_INTERVAL = 1
 
 
 def init_db() -> None:
@@ -80,7 +79,10 @@ def monitor_active(skale: SkaleManager, skale_ima: SkaleIma, node_config: NodeCo
             logger.exception('Process manager procedure failed!')
         logger.info(f'Sleeping for {ACTIVE_SLEEP_INTERVAL}s after run_process_manager')
         time.sleep(ACTIVE_SLEEP_INTERVAL)
-        run_cleaner(skale, node_config, manager_cache)
+        try:
+            run_cleaner(skale, node_config, manager_cache)
+        except Exception:
+            logger.exception('Cleaner procedure failed!')
         logger.info(f'Sleeping for {ACTIVE_SLEEP_INTERVAL}s after run_cleaner')
         time.sleep(ACTIVE_SLEEP_INTERVAL)
 
@@ -167,14 +169,13 @@ def init_active() -> None:
 
 def run_active() -> None:
     logger.info('Starting active node worker')
-    try:
-        init_active()
-        while True:
+    while True:
+        try:
+            init_active()
             worker_active()
-            time.sleep(WORKER_RESTART_SLEEP_INTERVAL)
-    except Exception:
-        logger.exception('Admin worker failed')
-        time.sleep(ERROR_SLEEP_INTERVAL)
+        except Exception:
+            logger.exception('Admin worker failed')
+        time.sleep(WORKER_RESTART_SLEEP_INTERVAL)
 
 
 def run_passive() -> None:


### PR DESCRIPTION
This pull request fixes error handling in both admin worker modes - `run_active` (active nodes) and `run_passive` (sync nodes) - so that fatal worker failures become visible to monitoring.

**Problem**
                                                                                                                                                 
  - In `run_active`, any exception from `init_active()`/`worker_active()` was caught, logged — and then the function silently returned, so the process exited with code 0. Docker (`restart: unless-stopped`) kept restarting the container, but the clean exit code masked the crash.
  - The inner `while True` around `worker_active()` was dead code: `worker_active` never returns normally (it ends in `monitor_active`'s infinite loop), so the `sleep` after it was unreachable and no retry ever happened.                                                                            
  - `run_passive` retried the whole worker setup in-process every 2 seconds, forever. Since `monitor_passive` already protects its own loop, the outer retry only replayed the pre-monitor setup — up to ~16 eth RPC calls plus a ~433 KB re-download of the skale-manager ABI bundle per iteration — while the container stayed `running` and the log-mtime healthcheck stayed green, hiding the failure completely.

**Fix**
                                                                                                                                                 
  - Removes both loops and makes both workers exit with code 1 on unhandled failure. Docker restarts the container either way (the exit code does not affect `unless-stopped`), but the crash is now observable: `ExitCode: 1` in `docker inspect`, growing `RestartCount` and `die` events with `exitCode=1`. Docker's built-in restart backoff (100 ms doubling up to 60 s) throttles crash loops instead of a hand-rolled sleep.             
  - Removes the now-unused `WORKER_RESTART_SLEEP_INTERVAL` and `ERROR_SLEEP_INTERVAL` constants.